### PR TITLE
feat(chart): combine cash outcome and credit payment charts

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,8 +2,7 @@ import React, { useState, useMemo } from 'react';
 import type { Transaction, NetworthRecord, MonthlySummary } from '../lib/data';
 import { formatIdr } from '../lib/utils';
 import { updateTransactionApi, deleteTransactionApi } from '../lib/api';
-import CashOutcomeChart from './CashOutcomeChart';
-import CreditPaymentChart from './CreditPaymentChart';
+import OutcomeChart from './OutcomeChart';
 import NetworthChart from './NetworthChart';
 import CategoryChart from './CategoryChart';
 
@@ -144,16 +143,10 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
         </div>
       </div>
 
-      {/* Charts Row 1 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
-          <h2 className="text-lg font-semibold mb-4">Cash Outcome by Month</h2>
-          <CashOutcomeChart data={filteredSummaries} />
-        </div>
-        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
-          <h2 className="text-lg font-semibold mb-4">Credit Payment by Month</h2>
-          <CreditPaymentChart data={filteredSummaries} />
-        </div>
+      {/* Outcome Chart */}
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6">
+        <h2 className="text-lg font-semibold mb-4">Cash Outcome vs Credit Payment by Month</h2>
+        <OutcomeChart data={filteredSummaries} />
       </div>
 
       {/* Charts Row 2 */}

--- a/src/components/OutcomeChart.tsx
+++ b/src/components/OutcomeChart.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { MonthlySummary } from '../lib/data';
+import { formatIdr } from '../lib/utils';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+export default function OutcomeChart({ data }: { data: MonthlySummary[] }) {
+  const labels = data.map((d) => d.month);
+  const cashOutcomes = data.map((d) => d.outcome.cash);
+  const creditPayments = data.map((d) => d.outcome.credit_payment);
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Cash Outcome',
+        data: cashOutcomes,
+        backgroundColor: '#3b82f6',
+        borderRadius: 4,
+      },
+      {
+        label: 'Credit Payment',
+        data: creditPayments,
+        backgroundColor: '#f59e0b',
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: {
+          usePointStyle: true,
+          padding: 16,
+        },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx: any) => `${ctx.dataset.label}: ${formatIdr(ctx.parsed.y)}`,
+        },
+      },
+    },
+    scales: {
+      y: { beginAtZero: true },
+      x: {
+        ticks: {
+          maxRotation: 45,
+          minRotation: 45,
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="relative h-72">
+      <Bar data={chartData} options={options} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Related Issue
Closes #8

## Changes
- New `src/components/OutcomeChart.tsx` — grouped bar chart with Cash Outcome (blue) and Credit Payment (amber)
- Updated `src/components/Dashboard.tsx`:
  - Replaced dual side-by-side charts with single full-width chart
  - Added legend for series identification
  - Kept IDR tooltip formatting

## Before
Two separate bar charts side-by-side:
- Cash Outcome by Month
- Credit Payment by Month

## After
Single grouped bar chart:
- Cash Outcome vs Credit Payment by Month
- Both series visible per month for easy comparison

## Verification
- [x] `npm run build` passes
- [x] Dashboard renders correctly
- [x] No database changes
