### PR TITLE
fix(#20): add monthly_income table to initSchema

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -49,6 +49,13 @@ export function initSchema() {
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
 
+    CREATE TABLE IF NOT EXISTS monthly_income (
+      month TEXT PRIMARY KEY,
+      date TEXT NOT NULL,
+      income REAL NOT NULL DEFAULT 0,
+      other_income REAL NOT NULL DEFAULT 0
+    );
+
     CREATE INDEX IF NOT EXISTS idx_tx_month ON transactions(month);
     CREATE INDEX IF NOT EXISTS idx_tx_type ON transactions(type);
     CREATE INDEX IF NOT EXISTS idx_tx_date ON transactions(date);


### PR DESCRIPTION
Closes #20

The `monthly_income` table was added during FIN-023 but its `CREATE TABLE` statement was never added to `initSchema()`. This causes crashes on fresh installs or DB resets whenever any code queries `monthly_income`.

### Changes
- Added `CREATE TABLE IF NOT EXISTS monthly_income` to `initSchema()` in `src/lib/db.ts`
- Schema matches the existing production table: `month TEXT PRIMARY KEY`, `date TEXT NOT NULL`, `income REAL NOT NULL DEFAULT 0`, `other_income REAL NOT NULL DEFAULT 0`

### Verification
- `npm run build` passes
- Existing DB is unaffected (uses `IF NOT EXISTS`)
