### PR TITLE
feat(FIN-025): wire category colors to dashboard charts and badges

### DIFF
--- a/src/components/CategoryChart.tsx
+++ b/src/components/CategoryChart.tsx
@@ -2,18 +2,27 @@ import React from 'react';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
 import { formatIdr } from '../lib/utils';
+import type { Category } from '../lib/data';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-export default function CategoryChart({ data }: { data: Record<string, number> }) {
+const FALLBACK_COLORS = [
+  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
+];
+
+interface Props {
+  data: Record<string, number>;
+  categories?: Category[];
+}
+
+export default function CategoryChart({ data, categories = [] }: Props) {
   const entries = Object.entries(data).sort((a, b) => b[1] - a[1]).slice(0, 10);
   const labels = entries.map(([k]) => k);
   const values = entries.map(([_, v]) => v);
 
-  const colors = [
-    '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-    '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
-  ];
+  const colorMap = new Map(categories.map((c) => [c.name, c.color]));
+  const colors = labels.map((label, i) => colorMap.get(label) || FALLBACK_COLORS[i % FALLBACK_COLORS.length]);
 
   const chartData = {
     labels,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -255,6 +255,10 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                   .sort(([, a], [, b]) => b - a)
                   .map(([cat, amount]) => {
                     const limit = categoryMap[cat]?.monthly_limit ?? 0;
+                    const catColor = categoryMap[cat]?.color;
+                    const trackStyle = catColor
+                      ? { backgroundColor: `${catColor}26` } // 15% opacity hex
+                      : undefined;
                     if (limit <= 0) {
                       return (
                         <div key={cat}>
@@ -262,8 +266,8 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                             <span className="text-slate-600 dark:text-slate-300">{cat}</span>
                             <span className="font-semibold">{formatIdr(amount)}</span>
                           </div>
-                          <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
-                            <div className="bg-slate-400 h-1.5 rounded-full" style={{ width: '100%' }} />
+                          <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5" style={trackStyle}>
+                            <div className="h-1.5 rounded-full" style={{ width: '100%', backgroundColor: catColor || '#94a3b8' }} />
                           </div>
                         </div>
                       );
@@ -280,7 +284,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                             {formatIdr(amount)} / {formatIdr(limit)}
                           </span>
                         </div>
-                        <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
+                        <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5" style={trackStyle}>
                           <div className={`${barColor} h-1.5 rounded-full transition-all`} style={{ width: `${pct}%` }} />
                         </div>
                       </div>
@@ -416,7 +420,15 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                     </TableCell>
                     <TableCell>{row.title}</TableCell>
                     <TableCell>
-                      <Badge variant="secondary">{row.category}</Badge>
+                      <Badge
+                        variant="secondary"
+                        style={{
+                          backgroundColor: categoryMap[row.category]?.color || undefined,
+                          color: categoryMap[row.category]?.color ? '#fff' : undefined,
+                        }}
+                      >
+                        {row.category}
+                      </Badge>
                     </TableCell>
                     <TableCell className="text-muted-foreground text-xs">{dateStr}</TableCell>
                     <TableCell className="font-medium text-right">{formatIdr(row.amount)}</TableCell>
@@ -487,7 +499,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
             {isAllTime ? 'Latest Month Categories' : `${latest.month} Categories`}
           </h2>
           {latest?.category_totals && Object.keys(latest.category_totals).length > 0 ? (
-            <CategoryChart data={latest.category_totals} />
+            <CategoryChart data={latest.category_totals} categories={categories} />
           ) : (
             <p className="text-slate-500 text-sm">No category data available.</p>
           )}

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useMemo } from 'react';
-import type { Transaction } from '../lib/data';
-import { updateTransactionApi, deleteTransactionApi, toggleTransactionDoneApi, deleteTransactionsBulkApi } from '../lib/api';
+import React, { useState, useMemo, useEffect } from 'react';
+import type { Transaction, Category } from '../lib/data';
+import { updateTransactionApi, deleteTransactionApi, toggleTransactionDoneApi, deleteTransactionsBulkApi, fetchCategories } from '../lib/api';
 import { formatIdr } from '../lib/utils';
 import {
   Table,
@@ -48,7 +48,18 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState<Partial<Transaction>>({});
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [categories, setCategories] = useState<Category[]>([]);
   const rowsPerPage = 25;
+
+  useEffect(() => {
+    fetchCategories().then(setCategories).catch(() => {});
+  }, []);
+
+  const categoryMap = useMemo(() => {
+    const map: Record<string, Category> = {};
+    categories.forEach((c) => { map[c.name] = c; });
+    return map;
+  }, [categories]);
 
   const sorted = useMemo(() => {
     return [...transactions].sort((a, b) => {
@@ -311,7 +322,15 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
                   {showMonth && <TableCell className="font-medium">{row.month}</TableCell>}
                   <TableCell>{row.title}</TableCell>
                   <TableCell>
-                    <Badge variant="secondary">{row.category}</Badge>
+                    <Badge
+                      variant="secondary"
+                      style={{
+                        backgroundColor: categoryMap[row.category]?.color || undefined,
+                        color: categoryMap[row.category]?.color ? '#fff' : undefined,
+                      }}
+                    >
+                      {row.category}
+                    </Badge>
                   </TableCell>
                   <TableCell className="text-muted-foreground text-xs">{dateStr}</TableCell>
                   <TableCell className="font-medium text-right">{formatIdr(row.amount)}</TableCell>


### PR DESCRIPTION
Closes #22

## What changed
- **CategoryChart**: now accepts a `categories` prop and uses the color defined in Settings for each category slice. Falls back to the original hardcoded palette for unknown categories.
- **Dashboard**: passes the fetched `categories` array to `CategoryChart`. Category badges in the transaction table now render with the category color as background. Category budget bars use the category color at 15% opacity for the track background, and unknown categories get a slate gray bar.
- **TransactionTable**: fetches categories client-side and applies category colors to category badges.

## Build status
✅ Passes