### PR TITLE
feat(FIN-027): Add Data Import UI to Settings

### DIFF
--- a/ITERATION_LOG.md
+++ b/ITERATION_LOG.md
@@ -341,3 +341,25 @@ FIN-024: Add JSON/CSV export UI button since the `/api/export` endpoint already 
 ✅ Passes — live at `http://192.168.0.6:4321`
 
 ---
+
+## Iteration 15 — FIN-027
+**Date:** 2026-05-12
+**Issue:** #28
+**Branch:** `feat/FIN-027`
+**PR:** #29
+
+### What changed
+- Added `POST /api/import` endpoint supporting JSON and CSV import for transactions, networth, and monthly_income
+- Added `importDataApi()` client helper in `src/lib/api.ts`
+- Created `ImportData.tsx` component with:
+  - File upload (JSON or CSV)
+  - Auto-detection of format and data type from JSON keys
+  - Manual type selection for CSV
+  - Preview table showing first 5 rows
+  - Import summary (imported / skipped / errors)
+- Integrated `ImportData` into `/settings` page between Export and Income settings
+
+### Build status
+✅ Passes — live at `http://192.168.0.6:4321`
+
+---

--- a/dist/server/entry.mjs
+++ b/dist/server/entry.mjs
@@ -1,24 +1,25 @@
 import { renderers } from './renderers.mjs';
 import { c as createExports, s as serverEntrypointModule } from './chunks/_@astrojs-ssr-adapter_DX3j8JO6.mjs';
-import { manifest } from './manifest_D-1tN6qa.mjs';
+import { manifest } from './manifest_c4XE7kjY.mjs';
 
 const _page0 = () => import('./pages/_image.astro.mjs');
 const _page1 = () => import('./pages/add.astro.mjs');
 const _page2 = () => import('./pages/api/categories/_id_.astro.mjs');
 const _page3 = () => import('./pages/api/categories.astro.mjs');
 const _page4 = () => import('./pages/api/export.astro.mjs');
-const _page5 = () => import('./pages/api/income/_month_.astro.mjs');
-const _page6 = () => import('./pages/api/income.astro.mjs');
-const _page7 = () => import('./pages/api/networth/_month_.astro.mjs');
-const _page8 = () => import('./pages/api/networth.astro.mjs');
-const _page9 = () => import('./pages/api/summary.astro.mjs');
-const _page10 = () => import('./pages/api/transactions/_id_.astro.mjs');
-const _page11 = () => import('./pages/api/transactions.astro.mjs');
-const _page12 = () => import('./pages/networth/edit.astro.mjs');
-const _page13 = () => import('./pages/networth.astro.mjs');
-const _page14 = () => import('./pages/settings.astro.mjs');
-const _page15 = () => import('./pages/transactions.astro.mjs');
-const _page16 = () => import('./pages/index.astro.mjs');
+const _page5 = () => import('./pages/api/import.astro.mjs');
+const _page6 = () => import('./pages/api/income/_month_.astro.mjs');
+const _page7 = () => import('./pages/api/income.astro.mjs');
+const _page8 = () => import('./pages/api/networth/_month_.astro.mjs');
+const _page9 = () => import('./pages/api/networth.astro.mjs');
+const _page10 = () => import('./pages/api/summary.astro.mjs');
+const _page11 = () => import('./pages/api/transactions/_id_.astro.mjs');
+const _page12 = () => import('./pages/api/transactions.astro.mjs');
+const _page13 = () => import('./pages/networth/edit.astro.mjs');
+const _page14 = () => import('./pages/networth.astro.mjs');
+const _page15 = () => import('./pages/settings.astro.mjs');
+const _page16 = () => import('./pages/transactions.astro.mjs');
+const _page17 = () => import('./pages/index.astro.mjs');
 
 const pageMap = new Map([
     ["node_modules/astro/dist/assets/endpoint/node.js", _page0],
@@ -26,18 +27,19 @@ const pageMap = new Map([
     ["src/pages/api/categories/[id].ts", _page2],
     ["src/pages/api/categories/index.ts", _page3],
     ["src/pages/api/export.ts", _page4],
-    ["src/pages/api/income/[month].ts", _page5],
-    ["src/pages/api/income/index.ts", _page6],
-    ["src/pages/api/networth/[month].ts", _page7],
-    ["src/pages/api/networth/index.ts", _page8],
-    ["src/pages/api/summary.ts", _page9],
-    ["src/pages/api/transactions/[id].ts", _page10],
-    ["src/pages/api/transactions/index.ts", _page11],
-    ["src/pages/networth/edit.astro", _page12],
-    ["src/pages/networth.astro", _page13],
-    ["src/pages/settings.astro", _page14],
-    ["src/pages/transactions.astro", _page15],
-    ["src/pages/index.astro", _page16]
+    ["src/pages/api/import.ts", _page5],
+    ["src/pages/api/income/[month].ts", _page6],
+    ["src/pages/api/income/index.ts", _page7],
+    ["src/pages/api/networth/[month].ts", _page8],
+    ["src/pages/api/networth/index.ts", _page9],
+    ["src/pages/api/summary.ts", _page10],
+    ["src/pages/api/transactions/[id].ts", _page11],
+    ["src/pages/api/transactions/index.ts", _page12],
+    ["src/pages/networth/edit.astro", _page13],
+    ["src/pages/networth.astro", _page14],
+    ["src/pages/settings.astro", _page15],
+    ["src/pages/transactions.astro", _page16],
+    ["src/pages/index.astro", _page17]
 ]);
 const serverIslandMap = new Map();
 const _manifest = Object.assign(manifest, {

--- a/dist/server/pages/add.astro.mjs
+++ b/dist/server/pages/add.astro.mjs
@@ -1,103 +1,14 @@
 /* empty css                               */
 import { f as createComponent, j as renderComponent, r as renderTemplate, m as maybeRenderHead } from '../chunks/astro/server_BVE5k6Zu.mjs';
 import 'kleur/colors';
-import { c as cn, B as Button, $ as $$Layout } from '../chunks/button_3D6Qkda7.mjs';
-import { jsx, jsxs } from 'react/jsx-runtime';
-import * as React from 'react';
+import { B as Button, $ as $$Layout } from '../chunks/button_Bx8EVyLF.mjs';
+import { jsxs, jsx } from 'react/jsx-runtime';
 import { useState, useRef, useEffect } from 'react';
-import { f as fetchTransactions, I as Input, a as fetchNetworth, c as createNetworth } from '../chunks/input_BBUjP35A.mjs';
-import { C as Card, a as CardHeader, b as CardTitle, c as CardContent, L as Label, d as CardDescription } from '../chunks/label_CxbflgV1.mjs';
-import { B as Badge } from '../chunks/badge_BUBVXJLz.mjs';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
-import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_CVD_0lf_.mjs';
+import { f as fetchTransactions, B as Badge, I as Input, a as fetchNetworth, c as createNetworth } from '../chunks/badge_Co1MM_vK.mjs';
+import { C as Card, a as CardHeader, b as CardTitle, c as CardContent, L as Label, d as CardDescription } from '../chunks/label_B4dA29fh.mjs';
+import { D as Dialog, a as DialogContent, b as DialogHeader, c as DialogTitle, d as DialogDescription, e as DialogFooter } from '../chunks/dialog_D6p1s_OZ.mjs';
+import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_DBhyzp65.mjs';
 export { renderers } from '../renderers.mjs';
-
-const Dialog = DialogPrimitive.Root;
-const DialogPortal = DialogPrimitive.Portal;
-const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ jsx(
-  DialogPrimitive.Overlay,
-  {
-    ref,
-    className: cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    ),
-    ...props
-  }
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
-const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => /* @__PURE__ */ jsxs(DialogPortal, { children: [
-  /* @__PURE__ */ jsx(DialogOverlay, {}),
-  /* @__PURE__ */ jsxs(
-    DialogPrimitive.Content,
-    {
-      ref,
-      className: cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      ),
-      ...props,
-      children: [
-        children,
-        /* @__PURE__ */ jsxs(DialogPrimitive.Close, { className: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", children: [
-          /* @__PURE__ */ jsx(X, { className: "h-4 w-4" }),
-          /* @__PURE__ */ jsx("span", { className: "sr-only", children: "Close" })
-        ] })
-      ]
-    }
-  )
-] }));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
-const DialogHeader = ({
-  className,
-  ...props
-}) => /* @__PURE__ */ jsx(
-  "div",
-  {
-    className: cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    ),
-    ...props
-  }
-);
-DialogHeader.displayName = "DialogHeader";
-const DialogFooter = ({
-  className,
-  ...props
-}) => /* @__PURE__ */ jsx(
-  "div",
-  {
-    className: cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    ),
-    ...props
-  }
-);
-DialogFooter.displayName = "DialogFooter";
-const DialogTitle = React.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ jsx(
-  DialogPrimitive.Title,
-  {
-    ref,
-    className: cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    ),
-    ...props
-  }
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
-const DialogDescription = React.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ jsx(
-  DialogPrimitive.Description,
-  {
-    ref,
-    className: cn("text-sm text-muted-foreground", className),
-    ...props
-  }
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 const MONTH_OPTIONS$1 = [
   "January",

--- a/dist/server/pages/api/export.astro.mjs
+++ b/dist/server/pages/api/export.astro.mjs
@@ -1,4 +1,4 @@
-import { c as getTransactions, e as getNetworth, f as getMonthlySummary, h as db } from '../../chunks/db_DmlXICmv.mjs';
+import { c as getTransactions, e as getNetworth, f as getMonthlySummary, h as db } from '../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../renderers.mjs';
 
 function toCsv(rows, headers) {

--- a/dist/server/pages/api/networth.astro.mjs
+++ b/dist/server/pages/api/networth.astro.mjs
@@ -1,4 +1,4 @@
-import { e as getNetworth, p as upsertNetworth, r as recalcNetworthMoM } from '../../chunks/db_DmlXICmv.mjs';
+import { e as getNetworth, k as upsertNetworth, r as recalcNetworthMoM } from '../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../renderers.mjs';
 
 const GET = async () => {

--- a/dist/server/pages/api/networth/_month_.astro.mjs
+++ b/dist/server/pages/api/networth/_month_.astro.mjs
@@ -1,4 +1,4 @@
-import { n as deleteNetworth, r as recalcNetworthMoM, o as getNetworthByMonth, p as upsertNetworth } from '../../../chunks/db_DmlXICmv.mjs';
+import { p as deleteNetworth, r as recalcNetworthMoM, q as getNetworthByMonth, k as upsertNetworth } from '../../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../../renderers.mjs';
 
 const GET = async ({ params }) => {

--- a/dist/server/pages/api/summary.astro.mjs
+++ b/dist/server/pages/api/summary.astro.mjs
@@ -1,4 +1,4 @@
-import { f as getMonthlySummary, h as db } from '../../chunks/db_DmlXICmv.mjs';
+import { f as getMonthlySummary, h as db } from '../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../renderers.mjs';
 
 const GET = async () => {

--- a/dist/server/pages/api/transactions.astro.mjs
+++ b/dist/server/pages/api/transactions.astro.mjs
@@ -1,4 +1,4 @@
-import { v as deleteTransactionsBulk, c as getTransactions, w as findDuplicateTransaction, x as insertTransaction } from '../../chunks/db_DmlXICmv.mjs';
+import { w as deleteTransactionsBulk, c as getTransactions, x as findDuplicateTransaction, j as insertTransaction } from '../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../renderers.mjs';
 
 const GET = async ({ request }) => {

--- a/dist/server/pages/api/transactions/_id_.astro.mjs
+++ b/dist/server/pages/api/transactions/_id_.astro.mjs
@@ -1,4 +1,4 @@
-import { q as deleteTransaction, s as getTransactionById, t as updateTransaction } from '../../../chunks/db_DmlXICmv.mjs';
+import { s as deleteTransaction, t as getTransactionById, v as updateTransaction } from '../../../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../../../renderers.mjs';
 
 const GET = async ({ params }) => {

--- a/dist/server/pages/index.astro.mjs
+++ b/dist/server/pages/index.astro.mjs
@@ -1,17 +1,17 @@
 /* empty css                               */
 import { f as createComponent, j as renderComponent, r as renderTemplate, m as maybeRenderHead } from '../chunks/astro/server_BVE5k6Zu.mjs';
 import 'kleur/colors';
-import { f as formatIdr, B as Button, $ as $$Layout } from '../chunks/button_3D6Qkda7.mjs';
+import { f as formatIdr, B as Button, $ as $$Layout } from '../chunks/button_Bx8EVyLF.mjs';
 import { jsx, jsxs } from 'react/jsx-runtime';
 import { useMemo, useState, useEffect } from 'react';
-import { b as fetchCategories, I as Input, t as toggleTransactionDoneApi, l as deleteTransactionApi, m as updateTransactionApi } from '../chunks/input_BBUjP35A.mjs';
+import { b as fetchCategories, I as Input, t as toggleTransactionDoneApi, B as Badge, m as deleteTransactionApi, n as updateTransactionApi } from '../chunks/badge_Co1MM_vK.mjs';
 import { Chart, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ArcElement } from 'chart.js';
 import { Bar, Doughnut } from 'react-chartjs-2';
-import { N as NetworthChart } from '../chunks/NetworthChart_DDO1bnV_.mjs';
-import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_BLw6Tfmc.mjs';
-import { B as Badge } from '../chunks/badge_BUBVXJLz.mjs';
-import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_CVD_0lf_.mjs';
-import { c as getTransactions, e as getNetworth, f as getMonthlySummary, h as db } from '../chunks/db_DmlXICmv.mjs';
+import { N as NetworthChart } from '../chunks/NetworthChart_D8imeaX_.mjs';
+import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_CbJIhMnF.mjs';
+import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_DBhyzp65.mjs';
+import { D as Dialog, a as DialogContent, b as DialogHeader, c as DialogTitle, d as DialogDescription } from '../chunks/dialog_D6p1s_OZ.mjs';
+import { c as getTransactions, e as getNetworth, f as getMonthlySummary, h as db } from '../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../renderers.mjs';
 
 Chart.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
@@ -68,22 +68,24 @@ function OutcomeChart({ data }) {
 }
 
 Chart.register(ArcElement, Tooltip, Legend);
-function CategoryChart({ data }) {
+const FALLBACK_COLORS = [
+  "#3b82f6",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#8b5cf6",
+  "#ec4899",
+  "#06b6d4",
+  "#84cc16",
+  "#f97316",
+  "#6366f1"
+];
+function CategoryChart({ data, categories = [], onCategoryClick }) {
   const entries = Object.entries(data).sort((a, b) => b[1] - a[1]).slice(0, 10);
   const labels = entries.map(([k]) => k);
   const values = entries.map(([_, v]) => v);
-  const colors = [
-    "#3b82f6",
-    "#10b981",
-    "#f59e0b",
-    "#ef4444",
-    "#8b5cf6",
-    "#ec4899",
-    "#06b6d4",
-    "#84cc16",
-    "#f97316",
-    "#6366f1"
-  ];
+  const colorMap = new Map(categories.map((c) => [c.name, c.color]));
+  const colors = labels.map((label, i) => colorMap.get(label) || FALLBACK_COLORS[i % FALLBACK_COLORS.length]);
   const chartData = {
     labels,
     datasets: [
@@ -97,10 +99,22 @@ function CategoryChart({ data }) {
   const options = {
     responsive: true,
     maintainAspectRatio: false,
+    onClick: (_evt, elements) => {
+      if (elements.length > 0 && onCategoryClick) {
+        const index = elements[0].index;
+        const category = labels[index];
+        if (category) onCategoryClick(category);
+      }
+    },
     plugins: {
       legend: {
         position: "right",
-        labels: { boxWidth: 12, font: { size: 11 } }
+        labels: { boxWidth: 12, font: { size: 11 } },
+        onClick: (_e, legendItem, _legend) => {
+          if (onCategoryClick && legendItem.text) {
+            onCategoryClick(legendItem.text);
+          }
+        }
       },
       tooltip: {
         callbacks: {
@@ -179,6 +193,12 @@ function Dashboard({ transactions, networth, summaries }) {
     fetchCategories().then(setCategories).catch(() => {
     });
   }, []);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const openCategoryDialog = (cat) => {
+    setSelectedCategory(cat);
+    setDialogOpen(true);
+  };
   const categoryMap = useMemo(() => {
     const map = {};
     categories.forEach((c) => {
@@ -278,20 +298,22 @@ function Dashboard({ transactions, networth, summaries }) {
           /* @__PURE__ */ jsx("h3", { className: "text-sm font-semibold mb-3 text-slate-700 dark:text-slate-200", children: "Category Budgets" }),
           /* @__PURE__ */ jsx("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3", children: Object.entries(latest.category_totals).sort(([, a], [, b]) => b - a).map(([cat, amount]) => {
             const limit = categoryMap[cat]?.monthly_limit ?? 0;
+            const catColor = categoryMap[cat]?.color;
+            const trackStyle = catColor ? { backgroundColor: `${catColor}26` } : void 0;
             if (limit <= 0) {
-              return /* @__PURE__ */ jsxs("div", { children: [
+              return /* @__PURE__ */ jsxs("div", { className: "cursor-pointer", onClick: () => openCategoryDialog(cat), children: [
                 /* @__PURE__ */ jsxs("div", { className: "flex justify-between text-sm mb-1", children: [
                   /* @__PURE__ */ jsx("span", { className: "text-slate-600 dark:text-slate-300", children: cat }),
                   /* @__PURE__ */ jsx("span", { className: "font-semibold", children: formatIdr(amount) })
                 ] }),
-                /* @__PURE__ */ jsx("div", { className: "w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5", children: /* @__PURE__ */ jsx("div", { className: "bg-slate-400 h-1.5 rounded-full", style: { width: "100%" } }) })
+                /* @__PURE__ */ jsx("div", { className: "w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5", style: trackStyle, children: /* @__PURE__ */ jsx("div", { className: "h-1.5 rounded-full", style: { width: "100%", backgroundColor: catColor || "#94a3b8" } }) })
               ] }, cat);
             }
             const pct = Math.min(100, amount / limit * 100);
             const isOver = amount > limit;
             const barColor = isOver ? "bg-red-500" : pct > 80 ? "bg-amber-500" : "bg-emerald-500";
             const textColor = isOver ? "text-red-600 dark:text-red-400" : pct > 80 ? "text-amber-600 dark:text-amber-400" : "text-emerald-600 dark:text-emerald-400";
-            return /* @__PURE__ */ jsxs("div", { children: [
+            return /* @__PURE__ */ jsxs("div", { className: "cursor-pointer", onClick: () => openCategoryDialog(cat), children: [
               /* @__PURE__ */ jsxs("div", { className: "flex justify-between text-sm mb-1", children: [
                 /* @__PURE__ */ jsx("span", { className: "text-slate-600 dark:text-slate-300", children: cat }),
                 /* @__PURE__ */ jsxs("span", { className: `font-semibold ${textColor}`, children: [
@@ -300,7 +322,7 @@ function Dashboard({ transactions, networth, summaries }) {
                   formatIdr(limit)
                 ] })
               ] }),
-              /* @__PURE__ */ jsx("div", { className: "w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5", children: /* @__PURE__ */ jsx("div", { className: `${barColor} h-1.5 rounded-full transition-all`, style: { width: `${pct}%` } }) })
+              /* @__PURE__ */ jsx("div", { className: "w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5", style: trackStyle, children: /* @__PURE__ */ jsx("div", { className: `${barColor} h-1.5 rounded-full transition-all`, style: { width: `${pct}%` } }) })
             ] }, cat);
           }) })
         ] })
@@ -406,7 +428,17 @@ function Dashboard({ transactions, networth, summaries }) {
               }
             ) }),
             /* @__PURE__ */ jsx(TableCell, { children: row.title }),
-            /* @__PURE__ */ jsx(TableCell, { children: /* @__PURE__ */ jsx(Badge, { variant: "secondary", children: row.category }) }),
+            /* @__PURE__ */ jsx(TableCell, { children: /* @__PURE__ */ jsx(
+              Badge,
+              {
+                variant: "secondary",
+                style: {
+                  backgroundColor: categoryMap[row.category]?.color || void 0,
+                  color: categoryMap[row.category]?.color ? "#fff" : void 0
+                },
+                children: row.category
+              }
+            ) }),
             /* @__PURE__ */ jsx(TableCell, { className: "text-muted-foreground text-xs", children: dateStr }),
             /* @__PURE__ */ jsx(TableCell, { className: "font-medium text-right", children: formatIdr(row.amount) }),
             /* @__PURE__ */ jsx(TableCell, { className: `${typeClass} text-xs font-semibold uppercase`, children: typeLabel }),
@@ -471,7 +503,7 @@ function Dashboard({ transactions, networth, summaries }) {
       ] }),
       /* @__PURE__ */ jsxs("div", { className: "bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 p-6", children: [
         /* @__PURE__ */ jsx("h2", { className: "text-lg font-semibold mb-4", children: isAllTime ? "Latest Month Categories" : `${latest.month} Categories` }),
-        latest?.category_totals && Object.keys(latest.category_totals).length > 0 ? /* @__PURE__ */ jsx(CategoryChart, { data: latest.category_totals }) : /* @__PURE__ */ jsx("p", { className: "text-slate-500 text-sm", children: "No category data available." })
+        latest?.category_totals && Object.keys(latest.category_totals).length > 0 ? /* @__PURE__ */ jsx(CategoryChart, { data: latest.category_totals, categories, onCategoryClick: openCategoryDialog }) : /* @__PURE__ */ jsx("p", { className: "text-slate-500 text-sm", children: "No category data available." })
       ] })
     ] }),
     /* @__PURE__ */ jsxs("div", { className: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4", children: [
@@ -508,7 +540,48 @@ function Dashboard({ transactions, networth, summaries }) {
         ] }),
         /* @__PURE__ */ jsx("div", { className: "w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2 mt-3", children: /* @__PURE__ */ jsx("div", { className: "bg-emerald-500 h-2 rounded-full transition-all", style: { width: `${Math.min(100, savingsRate)}%` } }) })
       ] })
-    ] })
+    ] }),
+    /* @__PURE__ */ jsx(Dialog, { open: dialogOpen, onOpenChange: setDialogOpen, children: /* @__PURE__ */ jsxs(DialogContent, { className: "max-w-2xl max-h-[80vh] overflow-y-auto", children: [
+      /* @__PURE__ */ jsxs(DialogHeader, { children: [
+        /* @__PURE__ */ jsxs(DialogTitle, { children: [
+          selectedCategory,
+          " — ",
+          isAllTime ? activeSummary.month : filterMonth
+        ] }),
+        /* @__PURE__ */ jsx(DialogDescription, { children: (() => {
+          const targetMonth = isAllTime ? activeSummary.month : filterMonth;
+          const catTxs = transactions.filter((t) => t.category === selectedCategory && t.month === targetMonth);
+          const total = catTxs.reduce((sum, t) => sum + t.amount, 0);
+          return `${catTxs.length} transaction${catTxs.length !== 1 ? "s" : ""} • Total: ${formatIdr(total)}`;
+        })() })
+      ] }),
+      /* @__PURE__ */ jsx("div", { className: "mt-2", children: (() => {
+        const targetMonth = isAllTime ? activeSummary.month : filterMonth;
+        const catTxs = transactions.filter((t) => t.category === selectedCategory && t.month === targetMonth).sort((a, b) => parseCreatedTime(b).getTime() - parseCreatedTime(a).getTime());
+        if (catTxs.length === 0) {
+          return /* @__PURE__ */ jsx("p", { className: "text-sm text-slate-500", children: "No transactions found for this category." });
+        }
+        return /* @__PURE__ */ jsxs(Table, { children: [
+          /* @__PURE__ */ jsx(TableHeader, { children: /* @__PURE__ */ jsxs(TableRow, { children: [
+            /* @__PURE__ */ jsx(TableHead, { children: "Title" }),
+            /* @__PURE__ */ jsx(TableHead, { children: "Date" }),
+            /* @__PURE__ */ jsx(TableHead, { className: "text-right", children: "Amount" }),
+            /* @__PURE__ */ jsx(TableHead, { children: "Type" })
+          ] }) }),
+          /* @__PURE__ */ jsx(TableBody, { children: catTxs.map((t) => {
+            const d = parseCreatedTime(t);
+            const dateStr = isNaN(d.getTime()) ? t.date : d.toLocaleDateString("id-ID", { year: "numeric", month: "short", day: "numeric" });
+            const typeLabel = t.type === "cash" ? "Cash" : t.type === "credit_payment" ? "Credit Pay" : "Credit";
+            return /* @__PURE__ */ jsxs(TableRow, { children: [
+              /* @__PURE__ */ jsx(TableCell, { className: "font-medium", children: t.title }),
+              /* @__PURE__ */ jsx(TableCell, { className: "text-muted-foreground text-xs", children: dateStr }),
+              /* @__PURE__ */ jsx(TableCell, { className: "text-right font-medium", children: formatIdr(t.amount) }),
+              /* @__PURE__ */ jsx(TableCell, { className: "text-xs font-semibold uppercase", children: /* @__PURE__ */ jsx(Badge, { variant: "outline", children: typeLabel }) })
+            ] }, t.id);
+          }) })
+        ] });
+      })() })
+    ] }) })
   ] });
 }
 

--- a/dist/server/pages/networth.astro.mjs
+++ b/dist/server/pages/networth.astro.mjs
@@ -1,12 +1,12 @@
 /* empty css                               */
 import { f as createComponent, j as renderComponent, r as renderTemplate, m as maybeRenderHead } from '../chunks/astro/server_BVE5k6Zu.mjs';
 import 'kleur/colors';
-import { f as formatIdr, B as Button, $ as $$Layout } from '../chunks/button_3D6Qkda7.mjs';
-import { N as NetworthChart } from '../chunks/NetworthChart_DDO1bnV_.mjs';
+import { f as formatIdr, B as Button, $ as $$Layout } from '../chunks/button_Bx8EVyLF.mjs';
+import { N as NetworthChart } from '../chunks/NetworthChart_D8imeaX_.mjs';
 import { jsx, jsxs } from 'react/jsx-runtime';
 import 'react';
-import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_BLw6Tfmc.mjs';
-import { e as getNetworth } from '../chunks/db_DmlXICmv.mjs';
+import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_CbJIhMnF.mjs';
+import { e as getNetworth } from '../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../renderers.mjs';
 
 function NetworthTable({ networth }) {

--- a/dist/server/pages/networth/edit.astro.mjs
+++ b/dist/server/pages/networth/edit.astro.mjs
@@ -1,12 +1,11 @@
 /* empty css                                  */
 import { f as createComponent, j as renderComponent, r as renderTemplate, m as maybeRenderHead } from '../../chunks/astro/server_BVE5k6Zu.mjs';
 import 'kleur/colors';
-import { B as Button, f as formatIdr, $ as $$Layout } from '../../chunks/button_3D6Qkda7.mjs';
+import { B as Button, f as formatIdr, $ as $$Layout } from '../../chunks/button_Bx8EVyLF.mjs';
 import { jsx, jsxs } from 'react/jsx-runtime';
 import { useState, useEffect } from 'react';
-import { a as fetchNetworth, I as Input, u as updateNetworthApi } from '../../chunks/input_BBUjP35A.mjs';
-import { C as Card, a as CardHeader, b as CardTitle, c as CardContent, L as Label } from '../../chunks/label_CxbflgV1.mjs';
-import { B as Badge } from '../../chunks/badge_BUBVXJLz.mjs';
+import { a as fetchNetworth, B as Badge, I as Input, u as updateNetworthApi } from '../../chunks/badge_Co1MM_vK.mjs';
+import { C as Card, a as CardHeader, b as CardTitle, c as CardContent, L as Label } from '../../chunks/label_B4dA29fh.mjs';
 export { renderers } from '../../renderers.mjs';
 
 function NetworthEditForm() {

--- a/dist/server/pages/transactions.astro.mjs
+++ b/dist/server/pages/transactions.astro.mjs
@@ -1,17 +1,16 @@
 /* empty css                               */
 import { f as createComponent, j as renderComponent, r as renderTemplate, m as maybeRenderHead } from '../chunks/astro/server_BVE5k6Zu.mjs';
 import 'kleur/colors';
-import { c as cn, B as Button, f as formatIdr, $ as $$Layout } from '../chunks/button_3D6Qkda7.mjs';
+import { c as cn, B as Button, f as formatIdr, $ as $$Layout } from '../chunks/button_Bx8EVyLF.mjs';
 import { jsx, jsxs } from 'react/jsx-runtime';
 import * as React from 'react';
-import { useState, useMemo } from 'react';
-import { I as Input, t as toggleTransactionDoneApi, l as deleteTransactionApi, m as updateTransactionApi, n as deleteTransactionsBulkApi } from '../chunks/input_BBUjP35A.mjs';
-import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_BLw6Tfmc.mjs';
-import { B as Badge } from '../chunks/badge_BUBVXJLz.mjs';
+import { useState, useEffect, useMemo } from 'react';
+import { b as fetchCategories, I as Input, t as toggleTransactionDoneApi, B as Badge, m as deleteTransactionApi, n as updateTransactionApi, o as deleteTransactionsBulkApi } from '../chunks/badge_Co1MM_vK.mjs';
+import { T as Table, a as TableHeader, b as TableRow, c as TableHead, d as TableBody, e as TableCell } from '../chunks/table_CbJIhMnF.mjs';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { Check } from 'lucide-react';
-import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_CVD_0lf_.mjs';
-import { c as getTransactions } from '../chunks/db_DmlXICmv.mjs';
+import { S as Select, a as SelectTrigger, b as SelectValue, c as SelectContent, d as SelectItem } from '../chunks/select_DBhyzp65.mjs';
+import { c as getTransactions } from '../chunks/db_B8cbmQtY.mjs';
 export { renderers } from '../renderers.mjs';
 
 const Checkbox = React.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ jsx(
@@ -53,7 +52,19 @@ function TransactionTable({ transactions, showMonth = true }) {
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState({});
   const [selected, setSelected] = useState(/* @__PURE__ */ new Set());
+  const [categories, setCategories] = useState([]);
   const rowsPerPage = 25;
+  useEffect(() => {
+    fetchCategories().then(setCategories).catch(() => {
+    });
+  }, []);
+  const categoryMap = useMemo(() => {
+    const map = {};
+    categories.forEach((c) => {
+      map[c.name] = c;
+    });
+    return map;
+  }, [categories]);
   const sorted = useMemo(() => {
     return [...transactions].sort((a, b) => {
       const da = parseCreatedTime(a);
@@ -275,7 +286,17 @@ function TransactionTable({ transactions, showMonth = true }) {
           ) }),
           showMonth && /* @__PURE__ */ jsx(TableCell, { className: "font-medium", children: row.month }),
           /* @__PURE__ */ jsx(TableCell, { children: row.title }),
-          /* @__PURE__ */ jsx(TableCell, { children: /* @__PURE__ */ jsx(Badge, { variant: "secondary", children: row.category }) }),
+          /* @__PURE__ */ jsx(TableCell, { children: /* @__PURE__ */ jsx(
+            Badge,
+            {
+              variant: "secondary",
+              style: {
+                backgroundColor: categoryMap[row.category]?.color || void 0,
+                color: categoryMap[row.category]?.color ? "#fff" : void 0
+              },
+              children: row.category
+            }
+          ) }),
           /* @__PURE__ */ jsx(TableCell, { className: "text-muted-foreground text-xs", children: dateStr }),
           /* @__PURE__ */ jsx(TableCell, { className: "font-medium text-right", children: formatIdr(row.amount) }),
           /* @__PURE__ */ jsx(TableCell, { className: `${typeClass} text-xs font-semibold uppercase`, children: typeLabel }),

--- a/src/components/ImportData.tsx
+++ b/src/components/ImportData.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useCallback } from 'react';
+import { importDataApi, type ImportResult } from '../lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+
+type ImportType = 'transactions' | 'networth' | 'monthly_income';
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    const nextChar = line[i + 1];
+    if (inQuotes) {
+      if (char === '"' && nextChar === '"') {
+        current += '"';
+        i++;
+      } else if (char === '"') {
+        inQuotes = false;
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        result.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.trim().split('\n');
+  if (lines.length < 2) return [];
+  const headers = parseCsvLine(lines[0]);
+  const rows: Record<string, string>[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const values = parseCsvLine(lines[i]);
+    const row: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      row[h] = values[idx] ?? '';
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function detectImportType(data: any): ImportType | null {
+  if (data && Array.isArray(data.transactions) && data.transactions.length > 0) return 'transactions';
+  if (data && Array.isArray(data.networth) && data.networth.length > 0) return 'networth';
+  if (data && Array.isArray(data.monthly_income) && data.monthly_income.length > 0) return 'monthly_income';
+  if (data && Array.isArray(data.monthlySummary) && data.monthlySummary.length > 0) return 'monthly_income'; // fallback hint
+  return null;
+}
+
+function extractRows(data: any, detectedType: ImportType | null): { rows: any[]; type: ImportType | null } {
+  if (!data) return { rows: [], type: null };
+  if (Array.isArray(data)) return { rows: data, type: detectedType };
+  if (detectedType === 'transactions' && Array.isArray(data.transactions)) return { rows: data.transactions, type: 'transactions' };
+  if (detectedType === 'networth' && Array.isArray(data.networth)) return { rows: data.networth, type: 'networth' };
+  if (detectedType === 'monthly_income' && Array.isArray(data.monthly_income)) return { rows: data.monthly_income, type: 'monthly_income' };
+  // Also check monthlySummary for income data hint
+  if (Array.isArray(data.monthly_income)) return { rows: data.monthly_income, type: 'monthly_income' };
+  return { rows: [], type: null };
+}
+
+export default function ImportData() {
+  const [file, setFile] = useState<File | null>(null);
+  const [fileContent, setFileContent] = useState<string>('');
+  const [format, setFormat] = useState<'json' | 'csv'>('json');
+  const [importType, setImportType] = useState<ImportType>('transactions');
+  const [previewRows, setPreviewRows] = useState<any[]>([]);
+  const [allRows, setAllRows] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string>('');
+
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+    setFile(selected);
+    setResult(null);
+    setError('');
+
+    const text = await selected.text();
+    setFileContent(text);
+
+    const isCsv = selected.name.toLowerCase().endsWith('.csv');
+    const detectedFormat: 'json' | 'csv' = isCsv ? 'csv' : 'json';
+    setFormat(detectedFormat);
+
+    if (detectedFormat === 'csv') {
+      const rows = parseCsv(text);
+      setAllRows(rows);
+      setPreviewRows(rows.slice(0, 5));
+      // Try to guess type from headers
+      const headers = text.trim().split('\n')[0]?.toLowerCase() || '';
+      if (headers.includes('title') && headers.includes('category')) {
+        setImportType('transactions');
+      } else if (headers.includes('investment') || headers.includes('total')) {
+        setImportType('networth');
+      } else if (headers.includes('income')) {
+        setImportType('monthly_income');
+      }
+    } else {
+      try {
+        const json = JSON.parse(text);
+        const detectedType = detectImportType(json);
+        const { rows, type } = extractRows(json, detectedType);
+        setAllRows(rows);
+        setPreviewRows(rows.slice(0, 5));
+        if (type) setImportType(type);
+      } catch {
+        setError('Invalid JSON file');
+        setAllRows([]);
+        setPreviewRows([]);
+      }
+    }
+  }, []);
+
+  const handleImport = async () => {
+    if (allRows.length === 0) {
+      setError('No data to import');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    setResult(null);
+    try {
+      const res = await importDataApi(importType, allRows);
+      setResult(res);
+      if (res.errors > 0) {
+        setError(`${res.errors} rows failed to import`);
+      }
+    } catch (err: any) {
+      setError(err.message || 'Import failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const previewHeaders = previewRows.length > 0 ? Object.keys(previewRows[0]) : [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import Data</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="import-file">File (JSON or CSV)</Label>
+          <Input id="import-file" type="file" accept=".json,.csv" onChange={handleFileChange} />
+        </div>
+
+        {file && (
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="space-y-1 flex-1">
+              <Label>Detected Format</Label>
+              <div className="text-sm text-muted-foreground capitalize">{format}</div>
+            </div>
+            <div className="space-y-1 flex-1">
+              <Label>Import Type</Label>
+              <Select value={importType} onValueChange={(v) => setImportType(v as ImportType)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="transactions">Transactions</SelectItem>
+                  <SelectItem value="networth">Networth</SelectItem>
+                  <SelectItem value="monthly_income">Monthly Income</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
+
+        {previewRows.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Preview ({allRows.length} rows)</Label>
+              <Badge variant="secondary">First 5 rows shown</Badge>
+            </div>
+            <div className="rounded-xl border overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {previewHeaders.map((h) => (
+                      <TableHead key={h}>{h}</TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {previewRows.map((row, idx) => (
+                    <TableRow key={idx}>
+                      {previewHeaders.map((h) => (
+                        <TableCell key={h} className="text-xs max-w-[200px] truncate">
+                          {String(row[h] ?? '')}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
+        )}
+
+        {result && (
+          <div className="rounded-lg bg-slate-50 dark:bg-slate-800 p-3 space-y-1">
+            <div className="text-sm font-medium">Import Result</div>
+            <div className="text-sm text-muted-foreground">
+              <span className="text-emerald-600 font-medium">{result.imported}</span> imported,{' '}
+              <span className="text-amber-600 font-medium">{result.skipped}</span> skipped,{' '}
+              <span className="text-red-600 font-medium">{result.errors}</span> errors
+            </div>
+          </div>
+        )}
+
+        {file && allRows.length > 0 && (
+          <Button onClick={handleImport} disabled={loading}>
+            {loading ? 'Importing...' : `Import ${allRows.length} Rows`}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -138,3 +138,22 @@ export async function updateMonthlyIncomeApi(month: string, record: Partial<Mont
 export async function deleteMonthlyIncomeApi(month: string): Promise<void> {
   await fetch(`/api/income/${encodeURIComponent(month)}`, { method: 'DELETE' });
 }
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: number;
+}
+
+export async function importDataApi(type: 'transactions' | 'networth' | 'monthly_income', rows: any[]): Promise<ImportResult> {
+  const res = await fetch('/api/import', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, rows }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Import failed' }));
+    throw new Error(err.error || 'Import failed');
+  }
+  return res.json();
+}

--- a/src/pages/api/import.ts
+++ b/src/pages/api/import.ts
@@ -1,0 +1,94 @@
+import type { APIRoute } from 'astro';
+import { insertTransaction, upsertNetworth, upsertMonthlyIncome } from '../../lib/db';
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const body = await request.json();
+    const { type, rows } = body;
+
+    if (!type || !Array.isArray(rows)) {
+      return new Response(JSON.stringify({ error: 'Missing type or rows' }), { status: 400 });
+    }
+
+    let imported = 0;
+    let skipped = 0;
+    let errors = 0;
+
+    if (type === 'transactions') {
+      for (const row of rows) {
+        try {
+          if (!row.month || !row.date || !row.title || !row.category || row.amount == null || !row.type) {
+            errors++;
+            continue;
+          }
+          const validTypes = ['cash', 'credit_expense', 'credit_payment'];
+          const txType = String(row.type);
+          if (!validTypes.includes(txType)) {
+            errors++;
+            continue;
+          }
+          insertTransaction({
+            month: String(row.month),
+            date: String(row.date),
+            title: String(row.title),
+            category: String(row.category),
+            amount: Number(row.amount),
+            currency: String(row.currency || 'IDR'),
+            type: txType,
+            payment_method: String(row.payment_method || 'unknown'),
+            done: row.done === true || row.done === 1 || row.done === '1' ? 1 : 0,
+            created_time: row.created_time || new Date().toISOString(),
+          });
+          imported++;
+        } catch {
+          errors++;
+        }
+      }
+    } else if (type === 'networth') {
+      for (const row of rows) {
+        try {
+          if (!row.month || !row.date || row.total == null) {
+            errors++;
+            continue;
+          }
+          upsertNetworth({
+            month: String(row.month),
+            date: String(row.date),
+            total: Number(row.total),
+            currency: String(row.currency || 'IDR'),
+            month_over_month_change: row.month_over_month_change != null ? Number(row.month_over_month_change) : null,
+            month_over_month_pct: row.month_over_month_pct != null ? Number(row.month_over_month_pct) : null,
+            breakdown: row.breakdown || {},
+          });
+          imported++;
+        } catch {
+          errors++;
+        }
+      }
+    } else if (type === 'monthly_income') {
+      for (const row of rows) {
+        try {
+          if (!row.month || !row.date || row.income == null) {
+            errors++;
+            continue;
+          }
+          upsertMonthlyIncome({
+            month: String(row.month),
+            date: String(row.date),
+            income: Number(row.income),
+            other_income: row.other_income != null ? Number(row.other_income) : 0,
+          });
+          imported++;
+        } catch {
+          errors++;
+        }
+      }
+    } else {
+      return new Response(JSON.stringify({ error: 'Invalid import type' }), { status: 400 });
+    }
+
+    return new Response(JSON.stringify({ imported, skipped, errors }), { status: 200 });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: err.message || 'Import failed' }), { status: 500 });
+  }
+};

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -3,12 +3,14 @@ import Layout from '../layouts/Layout.astro';
 import CategorySettings from '../components/CategorySettings';
 import IncomeSettings from '../components/IncomeSettings';
 import ExportData from '../components/ExportData';
+import ImportData from '../components/ImportData';
 ---
 
 <Layout title="Settings - Financial Dashboard">
   <div class="space-y-6">
     <h1 class="text-2xl font-bold">Settings</h1>
     <ExportData client:load />
+    <ImportData client:load />
     <IncomeSettings client:load />
     <CategorySettings client:load />
   </div>


### PR DESCRIPTION
Closes #28

### What changed
- Added `POST /api/import` endpoint supporting JSON and CSV import for transactions, networth, and monthly_income
- Added `importDataApi()` client helper in `src/lib/api.ts`
- Created `ImportData.tsx` component with:
  - File upload (JSON or CSV)
  - Auto-detection of format and data type from JSON keys
  - Manual type selection for CSV
  - Preview table showing first 5 rows
  - Import summary (imported / skipped / errors)
- Integrated `ImportData` into `/settings` page between Export and Income settings

### Build status
✅ Passes