### PR TITLE
feat(FIN-035): Export transactions as JSON for a specific month

### DIFF
--- a/ITERATION_LOG.md
+++ b/ITERATION_LOG.md
@@ -555,3 +555,26 @@ When total spending exceeds income (e.g., May 2026: income 18.5M vs outcome 20.5
 
 ### Build status
 ✅ Passes — `npm run build` clean
+
+## Iteration 24 — FIN-035: Export JSON for Specific Month
+
+**Date:** 2026-05-21
+**Issue:** [#38](https://github.com/akramram/self-financial-dashboard/issues/38)
+**Branch:** `feat/FIN-035`
+**PR:** [#39](https://github.com/akramram/self-financial-dashboard/pull/39)
+
+### What changed
+- Added **Export JSON** button next to the month/type filter row in `TransactionTable.tsx`
+- Exports all currently filtered transactions (respects month + type + search filters, NOT paginated)
+- Exported JSON shape: `date`, `description` (title), `amount`, `type`, `category`, `paid` (done)
+- File name: `transactions-YYYY-MM.json` when a specific month is selected, `transactions-all.json` otherwise
+- Shows `alert('No transactions found for this month')` when the filtered set is empty
+
+### Files changed
+- `src/components/TransactionTable.tsx`
+
+### Why it matters
+Users can now download transaction data for a specific month as structured JSON, making it easy to archive, share, or process in external tools.
+
+### Build status
+✅ Passes — `npm run build` clean

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -205,6 +205,36 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
             ))}
           </SelectContent>
         </Select>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            const exportData = filtered.map((t) => ({
+              date: t.date,
+              description: t.title,
+              amount: t.amount,
+              type: t.type,
+              category: t.category,
+              paid: t.done,
+            }));
+            if (exportData.length === 0) {
+              alert('No transactions found for this month');
+              return;
+            }
+            const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            const fileName = filterMonth !== 'all' ? `transactions-${filterMonth}.json` : 'transactions-all.json';
+            a.href = url;
+            a.download = fileName;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+          }}
+        >
+          Export JSON
+        </Button>
       </div>
 
       {selected.size > 0 && (


### PR DESCRIPTION
Closes #38

**Changes**
- Added 'Export JSON' button next to the month filter on the transactions page
- Exports all currently filtered transactions (respects month + type + search filters)
- Exported JSON fields: `date`, `description`, `amount`, `type`, `category`, `paid`
- File name: `transactions-YYYY-MM.json` when a month is selected, `transactions-all.json` otherwise
- Shows `alert('No transactions found for this month')` when the filtered set is empty

**Verification**
- `npm run build` passes
