### PR TITLE
feat(FIN-035): move month kickoff trigger from 25th to 21st

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -151,7 +151,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
   useEffect(() => {
     // Check if we should show the salary kickoff banner
     const today = new Date();
-    if (today.getDate() < 26) return;
+    if (today.getDate() < 21) return;
 
     const latest = summaries[summaries.length - 1];
     if (!latest) return;


### PR DESCRIPTION
Closes #42

Moves the salary kickoff banner trigger date from the 25th to the 21st of each month, giving users more time to prepare the new month.