### PR TITLE
feat(FIN-039): show all categories in Category Spending Trend chart

### DIFF
--- a/src/components/CategoryTrendChart.tsx
+++ b/src/components/CategoryTrendChart.tsx
@@ -48,10 +48,9 @@ export default function CategoryTrendChart({ data, categories = [] }: Props) {
       });
     });
 
-    // Pick top 6 categories by total spend
+    // Pick categories by total spend
     const topCategories = Object.entries(categoryTotals)
       .sort((a, b) => b[1] - a[1])
-      .slice(0, 6)
       .map(([name]) => name);
 
     const datasets = topCategories.map((cat, idx) => {


### PR DESCRIPTION
Closes #46

Removes the `.slice(0, 6)` limit so the Category Spending Trend line chart displays **all** categories instead of only the top 6 by total spend.

**Files changed:**
- `src/components/CategoryTrendChart.tsx`