### PR TITLE
feat(FIN-040): hide zero-spend categories from Category Spending Trend

### DIFF
--- a/src/components/CategoryTrendChart.tsx
+++ b/src/components/CategoryTrendChart.tsx
@@ -48,8 +48,9 @@ export default function CategoryTrendChart({ data, categories = [] }: Props) {
       });
     });
 
-    // Pick categories by total spend
+    // Pick categories by total spend, filtering out zero-spend ones
     const topCategories = Object.entries(categoryTotals)
+      .filter(([_, total]) => total > 0)
       .sort((a, b) => b[1] - a[1])
       .map(([name]) => name);
 


### PR DESCRIPTION
Closes #48

Adds a filter to exclude categories with 0 total spend across all months from the Category Spending Trend line chart. This keeps the legend clean and focused on categories that actually have spending data.

**Files changed:**
- `src/components/CategoryTrendChart.tsx`