### PR TITLE
feat(FIN-041): default period selector to current active period on Add Transaction page

### DIFF
--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createTransaction, fetchCategories } from '../lib/api';
 import type { Category } from '../lib/data';
+import { getActivePeriod } from '../lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -35,8 +36,9 @@ const TYPE_OPTIONS = [
 ];
 
 export default function AddTransactionForm() {
-  const [month, setMonth] = useState('May');
-  const [year, setYear] = useState(2026);
+  const { month: defaultMonth, year: defaultYear } = getActivePeriod();
+  const [month, setMonth] = useState(defaultMonth);
+  const [year, setYear] = useState(defaultYear);
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState('');
   const [amount, setAmount] = useState('');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,6 +15,28 @@ export function formatNumber(n: number | undefined | null): string {
   return Math.round(n).toLocaleString('id-ID');
 }
 
+/**
+ * Returns the current active billing period based on the 21st-of-month kickoff rule.
+ * If today is >= 21 → next calendar month.
+ * If today is < 21  → current calendar month.
+ */
+export function getActivePeriod(): { month: string; year: number } {
+  const now = new Date();
+  const day = now.getDate();
+  if (day >= 21) {
+    // Roll to next month
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return {
+      month: next.toLocaleDateString('en-US', { month: 'long' }),
+      year: next.getFullYear(),
+    };
+  }
+  return {
+    month: now.toLocaleDateString('en-US', { month: 'long' }),
+    year: now.getFullYear(),
+  };
+}
+
 export function getMonthSortKey(monthName: string): number {
   const monthMap: Record<string, number> = {
     january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,


### PR DESCRIPTION
Closes #50

## Changes
- Added `getActivePeriod()` utility in `src/lib/utils.ts` that computes the active billing period using the 21st-of-month kickoff rule
- Updated `AddTransactionForm` to use `getActivePeriod()` instead of hardcoded `May 2026` defaults

## Period Logic
| Today | Active Period |
|---|---|
| Before 21st | Current calendar month |
| 21st or later | Next calendar month |