### PR TITLE
feat(FIN-042): hide kickoff banner after user has already started the period

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -162,20 +162,24 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
     nextDate.setMonth(nextDate.getMonth() + 1);
     const nextMonthStr = nextDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 
-    // Check if next month already exists
-    const hasNext = summaries.some((s) => s.month === nextMonthStr);
-    if (hasNext) return;
+    // Check if next month already has data (income or transactions) via the kickoff API
+    fetch('/api/kickoff')
+      .then((res) => res.json())
+      .then((status: { hasNextMonth: boolean; nextMonth: string | null }) => {
+        if (status.hasNextMonth) return; // Already started — hide banner
 
-    // Fetch active recurring count
-    fetchRecurringTransactions().then((recurring) => {
-      const activeCount = recurring.filter((r) => r.active).length;
-      setKickoffBanner({
-        show: true,
-        currentMonth: latest.month,
-        nextMonth: nextMonthStr,
-        recurringCount: activeCount,
-      });
-    }).catch(() => {});
+        // Fetch active recurring count
+        fetchRecurringTransactions().then((recurring) => {
+          const activeCount = recurring.filter((r) => r.active).length;
+          setKickoffBanner({
+            show: true,
+            currentMonth: latest.month,
+            nextMonth: status.nextMonth || nextMonthStr,
+            recurringCount: activeCount,
+          });
+        }).catch(() => {});
+      })
+      .catch(() => {});
   }, [summaries]);
 
   const openCategoryDialog = (cat: string) => {


### PR DESCRIPTION
Closes #51

## Changes
- Refactored kickoff banner logic to use the `/api/kickoff` endpoint`s `hasNextMonth` field instead of only checking the `summaries` array
- The `/api/kickoff` endpoint correctly checks both `monthly_income` and `transactions` tables, so the banner now hides as soon as the user has completed the kickoff (added salary/income for the next period)

## Before
- Banner checked `summaries.some(s => s.month === nextMonthStr)` which missed months that only had income records (no summary computed yet)

## After
- Banner calls `/api/kickoff` and uses `hasNextMonth` — correctly detects started periods via income or transactions