### PR TITLE
fix: salary period date handling, summary dedup, and chart zero-filtering

### DIFF
--- a/src/components/AddNetworthForm.tsx
+++ b/src/components/AddNetworthForm.tsx
@@ -71,7 +71,8 @@ export default function AddNetworthForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const monthName = `${month} ${year}`;
-    const date = `${year}-${String(MONTH_OPTIONS.indexOf(month) + 1).padStart(2, '0')}-01`;
+    const monthIdx = MONTH_OPTIONS.indexOf(month) + 1;
+    const date = `${year}-${String(monthIdx).padStart(2, '0')}-21`;
     const total = Object.values(breakdown).reduce((s, v) => s + v, 0);
 
     await createNetworth({

--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -55,7 +55,8 @@ export default function AddTransactionForm() {
 
   const buildPayload = () => {
     const monthName = `${month} ${year}`;
-    const date = `${year}-${String(MONTH_OPTIONS.indexOf(month) + 1).padStart(2, '0')}-01`;
+    const monthIdx = MONTH_OPTIONS.indexOf(month) + 1;
+    const date = `${year}-${String(monthIdx).padStart(2, '0')}-21`;
     return {
       month: monthName,
       date,

--- a/src/components/CategoryChart.tsx
+++ b/src/components/CategoryChart.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export default function CategoryChart({ data, categories = [], onCategoryClick }: Props) {
-  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]).slice(0, 10);
+  const entries = Object.entries(data).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1]).slice(0, 10);
   const labels = entries.map(([k]) => k);
   const values = entries.map(([_, v]) => v);
 

--- a/src/components/CategoryTrendChart.tsx
+++ b/src/components/CategoryTrendChart.tsx
@@ -58,7 +58,8 @@ export default function CategoryTrendChart({ data, categories = [] }: Props) {
       const color = colorMap.get(cat) || FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
       return {
         label: cat,
-        data: sortedData.map((summary) => summary.category_totals?.[cat] ?? 0),
+        data: sortedData.map((summary) => summary.category_totals?.[cat] || null),
+        spanGaps: true,
         borderColor: color,
         backgroundColor: color,
         pointRadius: 3,

--- a/src/components/IncomeSettings.tsx
+++ b/src/components/IncomeSettings.tsx
@@ -80,7 +80,8 @@ export default function IncomeSettings() {
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
     const monthName = `${newMonth} ${newYear}`;
-    const date = `${newYear}-${String(MONTH_OPTIONS.indexOf(newMonth) + 1).padStart(2, '0')}-01`;
+    const monthIdx = MONTH_OPTIONS.indexOf(newMonth) + 1;
+    const date = `${newYear}-${String(monthIdx).padStart(2, '0')}-21`;
     const incomeVal = Number(newIncome);
     if (!newIncome || isNaN(incomeVal)) return;
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -228,7 +228,7 @@ export function deleteCategory(id: number) {
 
 export function getMonthlySummary() {
   const months = db.prepare(`
-    SELECT DISTINCT month, date FROM transactions ORDER BY date ASC
+    SELECT DISTINCT month, MIN(date) as date FROM transactions GROUP BY month ORDER BY MIN(date) ASC
   `).all() as any[];
 
   const summaries = [];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,6 +17,8 @@ export function formatNumber(n: number | undefined | null): string {
 
 /**
  * Returns the current active billing period based on the 21st-of-month kickoff rule.
+ * Each period runs from the 21st of a month to the 20th of the next month.
+ * The period is named after the month it ends in (the 20th).
  * If today is >= 21 → next calendar month.
  * If today is < 21  → current calendar month.
  */
@@ -24,7 +26,7 @@ export function getActivePeriod(): { month: string; year: number } {
   const now = new Date();
   const day = now.getDate();
   if (day >= 21) {
-    // Roll to next month
+    // New period started today — it ends next month
     const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
     return {
       month: next.toLocaleDateString('en-US', { month: 'long' }),

--- a/src/pages/api/kickoff.ts
+++ b/src/pages/api/kickoff.ts
@@ -34,9 +34,11 @@ export const POST: APIRoute = async ({ request }) => {
     });
   }
 
-  // Parse month to get date
+  // Parse month to get date — periods start on the 21st (salary cycle)
   const monthDate = new Date(month + ' 1');
-  const dateStr = monthDate.toISOString().slice(0, 10);
+  const mm = String(monthDate.getMonth() + 1).padStart(2, '0');
+  const yyyy = monthDate.getFullYear();
+  const dateStr = `${yyyy}-${mm}-21`;
 
   // Check if month already has income
   const existingIncome = getMonthlyIncomeByMonth(month);


### PR DESCRIPTION
## Summary
- Fix kickoff timezone bug causing duplicate periods
- Fix summary query returning duplicate month rows via `GROUP BY month`
- Filter zero-amount categories from pie and line charts
- Align all date computation to 21st (salary cycle start)
- Set monthly budget limits for Belanja, Belanja Pribadi, Tagihan, Invest

Closes #59