### PR TITLE
feat: Add sortable columns to all tables

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import type { Transaction, NetworthRecord, MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
 import { updateTransactionApi, deleteTransactionApi, toggleTransactionDoneApi, fetchCategories } from '../lib/api';
@@ -11,6 +11,8 @@ import FinancialInsights from './FinancialInsights';
 import OutcomeBarChart from './OutcomeBarChart';
 import MonthKickoffModal from './MonthKickoffModal';
 import { fetchRecurringTransactions } from '../lib/api';
+import { useSortState } from '../hooks/useSortState';
+import SortableHeader from './SortableHeader';
 import {
   Table,
   TableBody,
@@ -197,11 +199,25 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
     return map;
   }, [categories]);
 
+  const { toggleSort, sortData, isSorted } = useSortState();
+
+  const getTxCellValue = useCallback((t: Transaction, key: string): string | number => {
+    switch (key) {
+      case 'paid': return t.done ? 1 : 0;
+      case 'title': return t.title;
+      case 'category': return t.category;
+      case 'date': return new Date(t.created_time || t.date).getTime();
+      case 'amount': return t.amount;
+      case 'type': return t.type;
+      default: return '';
+    }
+  }, []);
+
   const sortedTransactions = useMemo(() => {
-    return [...filteredTransactions].sort(
-      (a, b) => parseCreatedTime(b).getTime() - parseCreatedTime(a).getTime()
+    return sortData(filteredTransactions, getTxCellValue, (data) =>
+      [...data].sort((a, b) => parseCreatedTime(b).getTime() - parseCreatedTime(a).getTime())
     );
-  }, [filteredTransactions]);
+  }, [filteredTransactions, sortData, getTxCellValue]);
 
   const totalTxPages = Math.max(1, Math.ceil(sortedTransactions.length / txPerPage));
   const pagedTransactions = sortedTransactions.slice(
@@ -426,12 +442,12 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Paid</TableHead>
-                <TableHead>Title</TableHead>
-                <TableHead>Category</TableHead>
-                <TableHead>Date</TableHead>
-                <TableHead className="text-right">Amount</TableHead>
-                <TableHead>Type</TableHead>
+                <SortableHeader sortKey="paid" currentDirection={isSorted('paid')} onSort={toggleSort}>Paid</SortableHeader>
+                <SortableHeader sortKey="title" currentDirection={isSorted('title')} onSort={toggleSort}>Title</SortableHeader>
+                <SortableHeader sortKey="category" currentDirection={isSorted('category')} onSort={toggleSort}>Category</SortableHeader>
+                <SortableHeader sortKey="date" currentDirection={isSorted('date')} onSort={toggleSort}>Date</SortableHeader>
+                <SortableHeader sortKey="amount" currentDirection={isSorted('amount')} onSort={toggleSort} className="text-right">Amount</SortableHeader>
+                <SortableHeader sortKey="type" currentDirection={isSorted('type')} onSort={toggleSort}>Type</SortableHeader>
                 <TableHead></TableHead>
               </TableRow>
             </TableHeader>

--- a/src/components/NetworthTable.tsx
+++ b/src/components/NetworthTable.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { NetworthRecord } from '../lib/data';
 import { formatIdr } from '../lib/utils';
+import { useSortState } from '../hooks/useSortState';
+import SortableHeader from './SortableHeader';
 import {
   Table,
   TableBody,
@@ -16,22 +18,36 @@ interface Props {
 }
 
 export default function NetworthTable({ networth }: Props) {
-  const networthReversed = [...networth].reverse();
+  const { toggleSort, sortData, isSorted } = useSortState();
+
+  const getCellValue = useCallback((row: NetworthRecord, key: string): string | number => {
+    switch (key) {
+      case 'month': return row.month;
+      case 'total': return row.total;
+      case 'change': return row.month_over_month_change ?? 0;
+      case 'pct': return row.month_over_month_pct ?? 0;
+      default: return '';
+    }
+  }, []);
+
+  const sortedRows = useMemo(() => {
+    return sortData(networth, getCellValue, (data) => [...data].reverse());
+  }, [networth, sortData, getCellValue]);
 
   return (
     <div className="rounded-xl border overflow-hidden">
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Month</TableHead>
-            <TableHead className="text-right">Total</TableHead>
-            <TableHead className="text-right">MoM Change</TableHead>
-            <TableHead className="text-right">MoM %</TableHead>
+            <SortableHeader sortKey="month" currentDirection={isSorted('month')} onSort={toggleSort}>Month</SortableHeader>
+            <SortableHeader sortKey="total" currentDirection={isSorted('total')} onSort={toggleSort} className="text-right">Total</SortableHeader>
+            <SortableHeader sortKey="change" currentDirection={isSorted('change')} onSort={toggleSort} className="text-right">MoM Change</SortableHeader>
+            <SortableHeader sortKey="pct" currentDirection={isSorted('pct')} onSort={toggleSort} className="text-right">MoM %</SortableHeader>
             <TableHead></TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {networthReversed.map((row) => (
+          {sortedRows.map((row) => (
             <TableRow key={row.month}>
               <TableCell className="font-medium">{row.month}</TableCell>
               <TableCell className="font-medium text-right">{formatIdr(row.total)}</TableCell>

--- a/src/components/SortableHeader.tsx
+++ b/src/components/SortableHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { TableHead } from '@/components/ui/table';
+import type { SortDirection } from '../hooks/useSortState';
+
+interface SortableHeaderProps {
+  children: React.ReactNode;
+  sortKey: string;
+  currentDirection: SortDirection | null;
+  onSort: (key: string) => void;
+  className?: string;
+}
+
+export default function SortableHeader({
+  children,
+  sortKey,
+  currentDirection,
+  onSort,
+  className,
+}: SortableHeaderProps) {
+  return (
+    <TableHead
+      className={`cursor-pointer select-none hover:bg-muted/50 transition-colors ${className ?? ''}`}
+      onClick={() => onSort(sortKey)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {children}
+        <span className="inline-flex flex-col leading-none text-[10px] ml-0.5">
+          <span
+            className={
+              currentDirection === 'asc'
+                ? 'text-foreground'
+                : 'text-muted-foreground/40'
+            }
+          >
+            ▲
+          </span>
+          <span
+            className={
+              currentDirection === 'desc'
+                ? 'text-foreground'
+                : 'text-muted-foreground/40'
+            }
+          >
+            ▼
+          </span>
+        </span>
+      </span>
+    </TableHead>
+  );
+}

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import type { Transaction, Category } from '../lib/data';
 import { updateTransactionApi, deleteTransactionApi, toggleTransactionDoneApi, deleteTransactionsBulkApi, fetchCategories } from '../lib/api';
 import { formatIdr } from '../lib/utils';
+import { useSortState } from '../hooks/useSortState';
+import SortableHeader from './SortableHeader';
 import {
   Table,
   TableBody,
@@ -70,6 +72,20 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [categories, setCategories] = useState<Category[]>([]);
   const rowsPerPage = 25;
+  const { toggleSort, sortData, isSorted } = useSortState();
+
+  const getCellValue = useCallback((t: Transaction, key: string): string | number => {
+    switch (key) {
+      case 'paid': return t.done ? 1 : 0;
+      case 'month': return t.month;
+      case 'title': return t.title;
+      case 'category': return t.category;
+      case 'date': return new Date(t.created_time || t.date).getTime();
+      case 'amount': return t.amount;
+      case 'type': return t.type;
+      default: return '';
+    }
+  }, []);
 
   useEffect(() => {
     fetchCategories().then(setCategories).catch(() => {});
@@ -107,12 +123,10 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
   }, [transactions]);
 
   const sorted = useMemo(() => {
-    return [...transactions].sort((a, b) => {
-      const da = parseCreatedTime(a);
-      const db = parseCreatedTime(b);
-      return db.getTime() - da.getTime();
-    });
-  }, [transactions]);
+    return sortData(transactions, getCellValue, (data) =>
+      [...data].sort((a, b) => parseCreatedTime(b).getTime() - parseCreatedTime(a).getTime())
+    );
+  }, [transactions, sortData, getCellValue]);
 
   let filtered = sorted;
   if (filterType !== 'all') {
@@ -330,13 +344,13 @@ export default function TransactionTable({ transactions, showMonth = true }: Pro
                   aria-label="Select all"
                 />
               </TableHead>
-              <TableHead>Paid</TableHead>
-              {showMonth && <TableHead>Month</TableHead>}
-              <TableHead>Title</TableHead>
-              <TableHead>Category</TableHead>
-              <TableHead>Date</TableHead>
-              <TableHead className="text-right">Amount</TableHead>
-              <TableHead>Type</TableHead>
+              <SortableHeader sortKey="paid" currentDirection={isSorted('paid')} onSort={toggleSort}>Paid</SortableHeader>
+              {showMonth && <SortableHeader sortKey="month" currentDirection={isSorted('month')} onSort={toggleSort}>Month</SortableHeader>}
+              <SortableHeader sortKey="title" currentDirection={isSorted('title')} onSort={toggleSort}>Title</SortableHeader>
+              <SortableHeader sortKey="category" currentDirection={isSorted('category')} onSort={toggleSort}>Category</SortableHeader>
+              <SortableHeader sortKey="date" currentDirection={isSorted('date')} onSort={toggleSort}>Date</SortableHeader>
+              <SortableHeader sortKey="amount" currentDirection={isSorted('amount')} onSort={toggleSort} className="text-right">Amount</SortableHeader>
+              <SortableHeader sortKey="type" currentDirection={isSorted('type')} onSort={toggleSort}>Type</SortableHeader>
               <TableHead></TableHead>
             </TableRow>
           </TableHeader>

--- a/src/hooks/useSortState.ts
+++ b/src/hooks/useSortState.ts
@@ -1,0 +1,56 @@
+import { useState, useCallback } from 'react';
+
+export type SortDirection = 'asc' | 'desc';
+
+interface SortState {
+  key: string;
+  direction: SortDirection;
+}
+
+export function useSortState(defaultKey?: string, defaultDirection?: SortDirection) {
+  const [sort, setSort] = useState<SortState | null>(
+    defaultKey ? { key: defaultKey, direction: defaultDirection ?? 'desc' } : null
+  );
+
+  const toggleSort = useCallback((key: string) => {
+    setSort((prev) => {
+      if (prev?.key === key) {
+        return prev.direction === 'asc'
+          ? { key, direction: 'desc' }
+          : null; // third click resets
+      }
+      return { key, direction: 'asc' };
+    });
+  }, []);
+
+  const sortData = useCallback(
+    <T>(data: T[], getCellValue: (item: T, key: string) => string | number, defaultSort?: (data: T[]) => T[]) => {
+      if (!sort) return defaultSort ? defaultSort(data) : data;
+
+      return [...data].sort((a, b) => {
+        const valA = getCellValue(a, sort.key);
+        const valB = getCellValue(b, sort.key);
+
+        let cmp: number;
+        if (typeof valA === 'number' && typeof valB === 'number') {
+          cmp = valA - valB;
+        } else {
+          cmp = String(valA ?? '').localeCompare(String(valB ?? ''));
+        }
+
+        return sort.direction === 'asc' ? cmp : -cmp;
+      });
+    },
+    [sort]
+  );
+
+  const isSorted = useCallback(
+    (key: string): SortDirection | null => {
+      if (sort?.key === key) return sort.direction;
+      return null;
+    },
+    [sort]
+  );
+
+  return { sort, toggleSort, sortData, isSorted };
+}


### PR DESCRIPTION
## What
Client-side sorting on every column in all data tables. Click a header → asc → desc → reset.

## Files
- `src/hooks/useSortState.ts` — reusable sort hook
- `src/components/SortableHeader.tsx` — clickable header with ▲▼ arrows
- `src/components/TransactionTable.tsx` — 7 sortable columns
- `src/components/NetworthTable.tsx` — 4 sortable columns
- `src/components/Dashboard.tsx` — 6 sortable columns (mini tx table)

Closes #62, closes #61