### PR TITLE
fix: stop Chart.js infinite resize loop on RecurringBreakdown (#64)

### DIFF
--- a/src/components/RecurringBreakdown.tsx
+++ b/src/components/RecurringBreakdown.tsx
@@ -332,11 +332,13 @@ export default function RecurringBreakdown() {
           </CardHeader>
           <CardContent>
             {donutData ? (
-              <div className="max-w-[280px] mx-auto">
+              <div className="max-w-[280px] mx-auto" style={{ height: 280 }}>
                 <Doughnut
                   data={donutData}
                   options={{
                     responsive: true,
+                    maintainAspectRatio: false,
+                    animation: false,
                     plugins: {
                       legend: {
                         position: 'bottom',
@@ -387,62 +389,66 @@ export default function RecurringBreakdown() {
           </CardHeader>
           <CardContent>
             {trendData ? (
-              <Line
-                data={trendData}
-                options={{
-                  responsive: true,
-                  interaction: {
-                    mode: 'index',
-                    intersect: false,
-                  },
-                  plugins: {
-                    legend: {
-                      position: 'bottom',
-                      labels: {
-                        usePointStyle: true,
-                        padding: 16,
-                      },
+              <div style={{ height: 300 }}>
+                <Line
+                  data={trendData}
+                  options={{
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    animation: false,
+                    interaction: {
+                      mode: 'index',
+                      intersect: false,
                     },
-                  },
-                  scales: {
-                    y: {
-                      type: 'linear',
-                      display: true,
-                      position: 'left',
-                      title: {
-                        display: true,
-                        text: '% of Total',
-                      },
-                      min: 0,
-                      max: 100,
-                      ticks: {
-                        callback: (v) => v + '%',
-                      },
-                    },
-                    y1: {
-                      type: 'linear',
-                      display: true,
-                      position: 'right',
-                      title: {
-                        display: true,
-                        text: 'Amount',
-                      },
-                      grid: {
-                        drawOnChartArea: false,
-                      },
-                      ticks: {
-                        callback: (v) => {
-                          const n = v as number;
-                          if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-                          if (n >= 1_000) return (n / 1_000).toFixed(0) + 'K';
-                          return n.toString();
+                    plugins: {
+                      legend: {
+                        position: 'bottom',
+                        labels: {
+                          usePointStyle: true,
+                          padding: 16,
                         },
                       },
                     },
-                  },
-                }}
+                    scales: {
+                      y: {
+                        type: 'linear',
+                        display: true,
+                        position: 'left',
+                        title: {
+                          display: true,
+                          text: '% of Total',
+                        },
+                        min: 0,
+                        max: 100,
+                        ticks: {
+                          callback: (v) => v + '%',
+                        },
+                      },
+                      y1: {
+                        type: 'linear',
+                        display: true,
+                        position: 'right',
+                        title: {
+                          display: true,
+                          text: 'Amount',
+                        },
+                        grid: {
+                          drawOnChartArea: false,
+                        },
+                        ticks: {
+                          callback: (v) => {
+                            const n = v as number;
+                            if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+                            if (n >= 1_000) return (n / 1_000).toFixed(0) + 'K';
+                            return n.toString();
+                          },
+                        },
+                      },
+                    },
+                  }}
               />
-            ) : (
+              </div>
+              ) : (
               <div className="flex items-center justify-center h-48 text-slate-400">
                 Need at least 2 periods of data
               </div>


### PR DESCRIPTION
Closes #64

## What
Fixes the "Current Breakdown" doughnut chart continuously resizing in a loop.

## Changes
- `maintainAspectRatio: false` on Doughnut and Line charts
- `animation: false` to prevent re-render cycles
- Fixed container height (280px / 300px) so parent doesn't shift