### PR TITLE
fix: resolve period_id and handle null params in networth API

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -306,19 +306,27 @@ export function getNetworthByPeriod(periodId: number) {
 }
 
 export function upsertNetworth(record: any) {
+  const safeRecord = {
+    period_id: record.period_id,
+    date: record.date,
+    total: record.total,
+    currency: record.currency || 'IDR',
+    month_over_month_change: record.month_over_month_change ?? null,
+    month_over_month_pct: record.month_over_month_pct ?? null,
+  };
   const existing = db.prepare('SELECT period_id FROM networth WHERE period_id = ?').get(record.period_id);
   if (existing) {
     db.prepare(`
       UPDATE networth SET date = @date, total = @total, currency = @currency,
       month_over_month_change = @month_over_month_change, month_over_month_pct = @month_over_month_pct
       WHERE period_id = @period_id
-    `).run(record);
+    `).run(safeRecord);
     db.prepare('DELETE FROM networth_breakdown WHERE period_id = ?').run(record.period_id);
   } else {
     db.prepare(`
       INSERT INTO networth (period_id, date, total, currency, month_over_month_change, month_over_month_pct)
       VALUES (@period_id, @date, @total, @currency, @month_over_month_change, @month_over_month_pct)
-    `).run(record);
+    `).run(safeRecord);
   }
   const insertBreakdown = db.prepare(`
     INSERT INTO networth_breakdown (period_id, investment, value) VALUES (@period_id, @investment, @value)

--- a/src/pages/api/networth/index.ts
+++ b/src/pages/api/networth/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getNetworth, upsertNetworth, recalcNetworthMoM } from '../../../lib/db';
+import { getNetworth, upsertNetworth, recalcNetworthMoM, ensurePeriod } from '../../../lib/db';
 
 export const GET: APIRoute = async () => {
   const rows = getNetworth();
@@ -10,6 +10,15 @@ export const GET: APIRoute = async () => {
 
 export const POST: APIRoute = async ({ request }) => {
   const body = await request.json();
+  if (!body.period_id && body.month) {
+    body.period_id = ensurePeriod(body.month);
+  }
+  if (!body.period_id) {
+    return new Response(JSON.stringify({ error: 'period_id or month is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
   upsertNetworth(body);
   recalcNetworthMoM();
   return new Response(JSON.stringify({ success: true }), {


### PR DESCRIPTION
Fixes #69

## Changes
- **API**: Add `ensurePeriod()` call in `POST /api/networth` to resolve `period_id` from `month` string when not provided
- **DB**: Normalize record fields in `upsertNetworth()` with `?? null` to prevent better-sqlite3 named parameter crash on undefined values