### PR TITLE
feat: Spending Streaks page - gamify no-spend days

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ const ALL_ITEMS: CommandItem[] = [
   { id: 'matrix', label: 'Spending Matrix', description: 'Category × period heatmap of all spending', icon: '🔳', group: 'pages', href: '/matrix' },
   { id: 'cashflow', label: 'Cash Flow', description: 'Income vs outcome waterfall', icon: '💸', group: 'pages', href: '/cashflow' },
   { id: 'calendar', label: 'Spending Calendar', description: 'Calendar heatmap of daily spending', icon: '📅', group: 'pages', href: '/calendar' },
+  { id: 'streaks', label: 'Spending Streaks', description: 'No-spend day streaks, badges & patterns', icon: '🔥', group: 'pages', href: '/streaks' },
   { id: 'goals', label: 'Goals Tracker', description: 'Track financial goals progress', icon: '🎯', group: 'pages', href: '/goals' },
   { id: 'recurring', label: 'Recurring', description: 'Manage recurring transactions', icon: '🔄', group: 'pages', href: '/recurring' },
   { id: 'yearly', label: 'Yearly Report', description: 'Annual spending summary', icon: '📆', group: 'pages', href: '/yearly' },

--- a/src/components/SpendingStreaks.tsx
+++ b/src/components/SpendingStreaks.tsx
@@ -1,0 +1,514 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { formatIdr } from '../lib/utils';
+import {
+  Flame,
+  Trophy,
+  CalendarDays,
+  TrendingDown,
+  Sparkles,
+  Info,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+
+// ============================================================
+// NOTE: this data shape must match StreakResult in src/lib/db.ts.
+// We re-declare it locally (rather than importing from a server-only
+// module) so the client bundle stays clean. Any nested objects are
+// fetched at runtime from /api/streaks (NOT passed as Astro props),
+// which sidesteps the devalue serialization pitfall documented in
+// astro-pm2-hydration-fix.
+// ============================================================
+interface StreakDay {
+  date: string;
+  dow: number;
+  isNoSpend: boolean;
+  txCount: number;
+  total: number;
+}
+interface DayOfWeekPattern {
+  dow: number;
+  label: string;
+  spendDays: number;
+  noSpendDays: number;
+  totalSpend: number;
+  avgPerSpendDay: number;
+}
+interface StreakBadge {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  unlocked: boolean;
+  progress?: { current: number; target: number };
+}
+interface StreakResult {
+  currentStreak: number;
+  longestStreak: number;
+  todayIsNoSpend: boolean;
+  yesterdayWasNoSpend: boolean;
+  noSpendLast30: number;
+  noSpendLast90: number;
+  totalDaysTracked: number;
+  firstTrackedDate: string | null;
+  recentDays: StreakDay[];
+  dowPattern: DayOfWeekPattern[];
+  badges: StreakBadge[];
+  recentNoSpendDays: string[];
+}
+
+const DOW_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  return `${DOW_SHORT[d.getDay()]}, ${MONTH_SHORT[d.getMonth()]} ${d.getDate()}`;
+}
+
+// Heat color for a spend day (no-spend days are emerald; spend days scale with intensity)
+function spendIntensity(total: number): string {
+  if (total <= 0) return '';
+  // Buckets: <200k, <500k, <1M, <2M, >=2M
+  if (total < 200000) return 'bg-amber-200 dark:bg-amber-900/50';
+  if (total < 500000) return 'bg-amber-300 dark:bg-amber-800/60';
+  if (total < 1000000) return 'bg-orange-300 dark:bg-orange-800/70';
+  if (total < 2000000) return 'bg-orange-400 dark:bg-orange-700/80';
+  return 'bg-red-500 dark:bg-red-600/90';
+}
+
+export default function SpendingStreaks() {
+  const [data, setData] = useState<StreakResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDay, setSelectedDay] = useState<StreakDay | null>(null);
+  const [dayTransactions, setDayTransactions] = useState<any[] | null>(null);
+  const [dialogLoading, setDialogLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/streaks')
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d: StreakResult) => setData(d))
+      .catch((e) => setError(e.message || String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Day-of-week pattern: find the heaviest weekday for actionable insight
+  const heaviestWeekday = useMemo(() => {
+    if (!data) return null;
+    const sorted = [...data.dowPattern].sort((a, b) => b.avgPerSpendDay - a.avgPerSpendDay);
+    return sorted[0] ?? null;
+  }, [data]);
+
+  const bestWeekday = useMemo(() => {
+    if (!data) return null;
+    // Best = highest no-spend ratio
+    const enriched = data.dowPattern.map((d) => {
+      const total = d.spendDays + d.noSpendDays;
+      return { ...d, noSpendRatio: total > 0 ? d.noSpendDays / total : 0 };
+    });
+    enriched.sort((a, b) => b.noSpendRatio - a.noSpendRatio);
+    return enriched[0] ?? null;
+  }, [data]);
+
+  const openDayDialog = async (day: StreakDay) => {
+    setSelectedDay(day);
+    setDayTransactions(null);
+    setDialogLoading(true);
+    try {
+      const res = await fetch(`/api/transactions-by-date?day=${encodeURIComponent(day.date)}`);
+      if (res.ok) {
+        const json = await res.json();
+        setDayTransactions(Array.isArray(json) ? json : []);
+      } else {
+        setDayTransactions([]);
+      }
+    } catch {
+      setDayTransactions([]);
+    } finally {
+      setDialogLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-slate-500 dark:text-slate-400">
+        <div className="animate-pulse">Loading streaks…</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-xl p-6 text-center">
+        <p className="text-red-700 dark:text-red-400 font-medium">Couldn't load streaks</p>
+        <p className="text-sm text-red-500 dark:text-red-500/80 mt-1">{error || 'No data'}</p>
+      </div>
+    );
+  }
+
+  const noSpendRatio30 = data.totalDaysTracked > 0
+    ? Math.round((data.noSpendLast30 / Math.min(30, data.totalDaysTracked)) * 100)
+    : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* ===== Headline streak cards ===== */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {/* Current streak */}
+        <div className={`rounded-xl border p-6 shadow-sm transition ${
+          data.currentStreak > 0
+            ? 'bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-950/40 dark:to-amber-950/30 border-orange-200 dark:border-orange-800'
+            : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700'
+        }`}>
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Current Streak
+            </p>
+            <Flame className={`w-5 h-5 ${data.currentStreak > 0 ? 'text-orange-500' : 'text-slate-300 dark:text-slate-600'}`} />
+          </div>
+          <p className={`text-4xl font-bold mt-3 ${data.currentStreak > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-slate-400 dark:text-slate-500'}`}>
+            {data.currentStreak}
+            <span className="text-lg font-medium ml-1">day{data.currentStreak === 1 ? '' : 's'}</span>
+          </p>
+          <p className="text-xs mt-2 text-slate-500 dark:text-slate-400">
+            {data.currentStreak > 0
+              ? data.todayIsNoSpend
+                ? '🔥 Keep it going today!'
+                : 'Ended yesterday — start a new one!'
+              : data.todayIsNoSpend
+                ? 'Today counts — spend nothing to start!'
+                : 'Spend nothing today to begin'}
+          </p>
+        </div>
+
+        {/* Longest streak */}
+        <div className="rounded-xl border p-6 shadow-sm bg-gradient-to-br from-violet-50 to-purple-50 dark:from-violet-950/40 dark:to-purple-950/30 border-violet-200 dark:border-violet-800">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Longest Streak
+            </p>
+            <Trophy className="w-5 h-5 text-violet-500" />
+          </div>
+          <p className="text-4xl font-bold mt-3 text-violet-600 dark:text-violet-400">
+            {data.longestStreak}
+            <span className="text-lg font-medium ml-1">day{data.longestStreak === 1 ? '' : 's'}</span>
+          </p>
+          <p className="text-xs mt-2 text-slate-500 dark:text-slate-400">Personal best 🏆</p>
+        </div>
+
+        {/* No-spend last 30 */}
+        <div className="rounded-xl border p-6 shadow-sm bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/40 dark:to-teal-950/30 border-emerald-200 dark:border-emerald-800">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              No-Spend (30d)
+            </p>
+            <CalendarDays className="w-5 h-5 text-emerald-500" />
+          </div>
+          <p className="text-4xl font-bold mt-3 text-emerald-600 dark:text-emerald-400">
+            {data.noSpendLast30}
+            <span className="text-lg font-medium ml-1">/ {Math.min(30, data.totalDaysTracked)}</span>
+          </p>
+          <div className="w-full bg-emerald-100 dark:bg-emerald-900/40 rounded-full h-1.5 mt-3">
+            <div className="h-1.5 rounded-full bg-emerald-500 transition-all" style={{ width: `${noSpendRatio30}%` }} />
+          </div>
+        </div>
+
+        {/* No-spend last 90 */}
+        <div className="rounded-xl border p-6 shadow-sm bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              No-Spend (90d)
+            </p>
+            <TrendingDown className="w-5 h-5 text-slate-400" />
+          </div>
+          <p className="text-4xl font-bold mt-3 text-slate-700 dark:text-slate-200">
+            {data.noSpendLast90}
+            <span className="text-lg font-medium ml-1">/ {Math.min(90, data.totalDaysTracked)}</span>
+          </p>
+          <p className="text-xs mt-2 text-slate-500 dark:text-slate-400">
+            {data.totalDaysTracked > 0
+              ? `${Math.round((data.noSpendLast90 / Math.min(90, data.totalDaysTracked)) * 100)}% of days`
+              : 'No data yet'}
+          </p>
+        </div>
+      </div>
+
+      {/* ===== 35-day strip + Day-of-week pattern ===== */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Contribution strip */}
+        <div className="lg:col-span-2 bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm p-6">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <Sparkles className="w-4 h-4 text-amber-500" /> Last 5 Weeks
+            </h2>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+            Green = no-spend day · warm colors = spending intensity. Click any day for details.
+          </p>
+
+          {/* Grid: columns = weeks, rows = Sun..Sat */}
+          <div className="flex gap-2 overflow-x-auto pb-2">
+            {chunkWeeks(data.recentDays).map((week, wi) => (
+              <div key={wi} className="flex flex-col gap-1.5">
+                {week.map((day) =>
+                  day ? (
+                    <button
+                      key={day.date}
+                      onClick={() => openDayDialog(day)}
+                      title={`${formatDateLabel(day.date)} · ${day.isNoSpend ? 'No spend' : formatIdr(day.total) + ' · ' + day.txCount + ' tx'}`}
+                      className={`w-9 h-9 rounded-md transition hover:ring-2 hover:ring-offset-1 hover:ring-offset-white dark:hover:ring-offset-slate-800 hover:ring-slate-400 ${
+                        day.isNoSpend
+                          ? 'bg-emerald-400 hover:bg-emerald-500 dark:bg-emerald-600'
+                          : spendIntensity(day.total)
+                      }`}
+                    />
+                  ) : (
+                    <div key={`empty-${wi}-${Math.random()}`} className="w-9 h-9" />
+                  )
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Legend */}
+          <div className="flex items-center gap-3 mt-4 text-xs text-slate-500 dark:text-slate-400 flex-wrap">
+            <span className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded-sm bg-emerald-400 dark:bg-emerald-600 inline-block" /> No spend
+            </span>
+            <span>Less</span>
+            <span className="w-3 h-3 rounded-sm bg-amber-200 dark:bg-amber-900/50 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-amber-300 dark:bg-amber-800/60 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-orange-300 dark:bg-orange-800/70 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-orange-400 dark:bg-orange-700/80 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-red-500 dark:bg-red-600/90 inline-block" />
+            <span>More</span>
+          </div>
+        </div>
+
+        {/* Day-of-week pattern */}
+        <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm p-6">
+          <h2 className="text-lg font-semibold mb-1">Spending by Weekday</h2>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">Last 90 days</p>
+          <div className="space-y-2.5">
+            {data.dowPattern.map((d) => {
+              const total = d.spendDays + d.noSpendDays;
+              const spendPct = total > 0 ? Math.round((d.spendDays / total) * 100) : 0;
+              const maxAvg = Math.max(...data.dowPattern.map((x) => x.avgPerSpendDay), 1);
+              const intensityPct = Math.round((d.avgPerSpendDay / maxAvg) * 100);
+              return (
+                <div key={d.dow}>
+                  <div className="flex items-center justify-between text-xs mb-1">
+                    <span className="font-medium text-slate-600 dark:text-slate-300">{d.label}</span>
+                    <span className="text-slate-400">
+                      {d.spendDays} spend · <span className="text-emerald-600 dark:text-emerald-400">{d.noSpendDays} no-spend</span>
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 h-2.5 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${intensityPct > 75 ? 'bg-red-400 dark:bg-red-500' : intensityPct > 50 ? 'bg-orange-400 dark:bg-orange-500' : 'bg-amber-400 dark:bg-amber-500'}`}
+                        style={{ width: `${spendPct}%` }}
+                      />
+                    </div>
+                    <span className="text-[10px] text-slate-400 w-16 text-right">
+                      {d.avgPerSpendDay > 0 ? formatIdr(d.avgPerSpendDay) : '—'}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {heaviestWeekday && heaviestWeekday.avgPerSpendDay > 0 && (
+            <div className="mt-4 pt-4 border-t border-slate-100 dark:border-slate-700">
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                <span className="font-semibold text-red-500">⚠ {heaviestWeekday.label}s</span> are your heaviest
+                spending days (avg {formatIdr(heaviestWeekday.avgPerSpendDay)}).
+                {bestWeekday && bestWeekday.label !== heaviestWeekday.label && (
+                  <> You're most disciplined on <span className="font-semibold text-emerald-600 dark:text-emerald-400">{bestWeekday.label}s</span>.</>
+                )}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ===== Badges ===== */}
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm p-6">
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Trophy className="w-4 h-4 text-amber-500" /> Badges
+          </h2>
+          <Badge variant="secondary">
+            {data.badges.filter((b) => b.unlocked).length} / {data.badges.length} unlocked
+          </Badge>
+        </div>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+          Earn badges by building no-spend streaks. Progress bars show how close you are.
+        </p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {data.badges.map((b) => (
+            <div
+              key={b.id}
+              className={`rounded-xl border p-4 transition ${
+                b.unlocked
+                  ? 'bg-gradient-to-br from-amber-50 to-yellow-50 dark:from-amber-950/30 dark:to-yellow-950/20 border-amber-200 dark:border-amber-800'
+                  : 'bg-slate-50 dark:bg-slate-900/40 border-slate-200 dark:border-slate-700 opacity-70'
+              }`}
+            >
+              <div className="flex items-start justify-between mb-2">
+                <span className={`text-3xl ${b.unlocked ? '' : 'grayscale opacity-50'}`}>{b.icon}</span>
+                {b.unlocked && <span className="text-[10px] font-bold uppercase text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">Earned</span>}
+              </div>
+              <p className={`font-semibold text-sm ${b.unlocked ? 'text-slate-800 dark:text-slate-100' : 'text-slate-500 dark:text-slate-400'}`}>
+                {b.label}
+              </p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{b.description}</p>
+              {!b.unlocked && b.progress && (
+                <div className="mt-2">
+                  <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
+                    <div className="h-1.5 rounded-full bg-amber-400 dark:bg-amber-500 transition-all" style={{ width: `${Math.min(100, (b.progress.current / b.progress.target) * 100)}%` }} />
+                  </div>
+                  <p className="text-[10px] text-slate-400 mt-1">{b.progress.current} / {b.progress.target}</p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ===== Recent no-spend days list ===== */}
+      {data.recentNoSpendDays.length > 0 && (
+        <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm p-6">
+          <h2 className="text-lg font-semibold flex items-center gap-2 mb-1">
+            <CalendarDays className="w-4 h-4 text-emerald-500" /> Recent No-Spend Days
+          </h2>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+            Last 30 days · {data.recentNoSpendDays.length} no-spend day{data.recentNoSpendDays.length === 1 ? '' : 's'}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {data.recentNoSpendDays.map((d) => {
+              const dt = new Date(d + 'T00:00:00');
+              return (
+                <span key={d} className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-800 text-sm text-emerald-700 dark:text-emerald-300">
+                  <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                  {DOW_SHORT[dt.getDay()]}, {MONTH_SHORT[dt.getMonth()]} {dt.getDate()}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* ===== Explanation footer ===== */}
+      <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-700 p-4 flex gap-3">
+        <Info className="w-4 h-4 text-slate-400 flex-shrink-0 mt-0.5" />
+        <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+          <strong>How it works:</strong> A <em>no-spend day</em> is any calendar day with zero
+          discretionary spending (cash or credit-card purchases). Credit-card
+          <em> payments</em> don't count — they're just moving money between accounts, not real spending.
+          Streaks reset the moment you make a purchase. Tracking started
+          {data.firstTrackedDate ? ` ${new Date(data.firstTrackedDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}` : ' recently'}
+          {data.totalDaysTracked > 0 && ` · ${data.totalDaysTracked} days tracked`}.
+        </p>
+      </div>
+
+      {/* ===== Day detail dialog ===== */}
+      <Dialog open={!!selectedDay} onOpenChange={(o) => !o && setSelectedDay(null)}>
+        <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {selectedDay?.isNoSpend ? (
+                <><span className="text-emerald-500">🎉</span> No-Spend Day</>
+              ) : (
+                <><span>💸</span> Spending Day</>
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {selectedDay && formatDateLabel(selectedDay.date)}
+              {selectedDay && !selectedDay.isNoSpend && (
+                <> · {formatIdr(selectedDay.total)} across {selectedDay.txCount} transaction{selectedDay.txCount === 1 ? '' : 's'}</>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedDay?.isNoSpend ? (
+            <div className="py-6 text-center">
+              <p className="text-3xl mb-2">🌱</p>
+              <p className="font-medium text-slate-700 dark:text-slate-200">No discretionary spending!</p>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                You kept money in your pocket all day. Every no-spend day extends your streak.
+              </p>
+            </div>
+          ) : dialogLoading ? (
+            <div className="py-8 text-center text-sm text-slate-500 animate-pulse">Loading transactions…</div>
+          ) : dayTransactions && dayTransactions.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {dayTransactions.map((t: any) => (
+                  <TableRow key={t.id}>
+                    <TableCell className="font-medium">{t.title}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">{t.category}</TableCell>
+                    <TableCell className="text-right font-medium">{formatIdr(t.amount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="py-4 text-sm text-slate-500 text-center">
+              Spending detected but no individual transactions found for this date.
+              (Transactions may use a different timestamp.)
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+/** Chunk the flat recentDays array (oldest→newest) into week columns aligned to Sunday. */
+function chunkWeeks(days: StreakDay[]): (StreakDay | null)[][] {
+  if (days.length === 0) return [];
+  const weeks: (StreakDay | null)[][] = [];
+  let currentWeek: (StreakDay | null)[] = [];
+
+  // Pad the first week so it starts on a Sunday
+  const firstDow = days[0].dow; // 0=Sun
+  for (let i = 0; i < firstDow; i++) currentWeek.push(null);
+
+  for (const day of days) {
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+    currentWeek.push(day);
+  }
+  // Pad the last week
+  while (currentWeek.length > 0 && currentWeek.length < 7) currentWeek.push(null);
+  if (currentWeek.length > 0) weeks.push(currentWeek);
+
+  return weeks;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -64,6 +64,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
         <a href="/matrix" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
         <a href="/cashflow" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Cash Flow</a>
         <a href="/calendar" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Calendar</a>
+        <a href="/streaks" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-orange-600 dark:text-orange-400">Streaks 🔥</a>
         <a href="/merchants" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-sky-600 dark:text-sky-400">Merchants</a>
         <a href="/goals" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Goals</a>
         <a href="/recurring" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Recurring</a>
@@ -92,6 +93,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
           <a href="/matrix" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
           <a href="/cashflow" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Cash Flow</a>
           <a href="/calendar" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Calendar</a>
+          <a href="/streaks" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-orange-600 dark:text-orange-400">Streaks 🔥</a>
           <a href="/merchants" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-sky-600 dark:text-sky-400">Merchants</a>
           <a href="/goals" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Goals</a>
           <a href="/recurring" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Recurring</a>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -219,6 +219,15 @@ export function getTransactionById(id: number) {
   return db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as any;
 }
 
+/** All transactions whose created_time (or date fallback) falls on the given YYYY-MM-DD day. */
+export function getTransactionsByDate(day: string) {
+  return db.prepare(`
+    SELECT * FROM transactions
+    WHERE SUBSTR(COALESCE(created_time, date), 1, 10) = ?
+    ORDER BY created_time DESC
+  `).all(day) as any[];
+}
+
 function normalizeTx(tx: any) {
   const copy = { ...tx };
   if (typeof copy.done === 'boolean') copy.done = copy.done ? 1 : 0;
@@ -617,6 +626,254 @@ export function getDayOfWeekSpending() {
     GROUP BY dow
     ORDER BY dow ASC
   `).all() as any[];
+}
+
+// ============================================================
+// Spending Streaks — gamify no-spend days
+// "No-spend day" = a calendar day with zero discretionary spending
+//   (discretionary = cash or credit_expense, excludes credit_payment
+//    which is just moving money between accounts, not real spending)
+// ============================================================
+
+export interface StreakDay {
+  date: string;          // YYYY-MM-DD
+  dow: number;           // 0=Sun .. 6=Sat
+  isNoSpend: boolean;
+  txCount: number;
+  total: number;
+}
+
+export interface DayOfWeekPattern {
+  dow: number;           // 0=Sun .. 6=Sat
+  label: string;
+  spendDays: number;     // distinct days with spending on this weekday
+  noSpendDays: number;   // distinct no-spend days on this weekday
+  totalSpend: number;
+  avgPerSpendDay: number;
+}
+
+export interface StreakBadge {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;          // emoji
+  unlocked: boolean;
+  progress?: { current: number; target: number };
+}
+
+export interface StreakResult {
+  currentStreak: number;
+  longestStreak: number;
+  todayIsNoSpend: boolean;
+  yesterdayWasNoSpend: boolean;
+  noSpendLast30: number;
+  noSpendLast90: number;
+  totalDaysTracked: number;
+  firstTrackedDate: string | null;
+  recentDays: StreakDay[];           // last 35 days, oldest→newest, for the strip
+  dowPattern: DayOfWeekPattern[];    // 7 entries
+  badges: StreakBadge[];
+  // recent no-spend days with a transaction drilldown (newest first)
+  recentNoSpendDays: string[];
+}
+
+const DOW_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export function getSpendingStreaks(): StreakResult {
+  // 1. Pull every distinct discretionary spend day (all-time), with totals.
+  //    created_time is the real per-day timestamp; date is just a period marker.
+  const spendDayRows = db.prepare(`
+    SELECT DATE(created_time) AS day,
+           COUNT(*) AS tx_count,
+           SUM(amount) AS total
+    FROM transactions
+    WHERE type IN ('cash', 'credit_expense')
+      AND done = 1
+      AND created_time IS NOT NULL
+      AND DATE(created_time) <= DATE('now')
+    GROUP BY day
+  `).all() as { day: string; tx_count: number; total: number }[];
+
+  const spendDaySet = new Set(spendDayRows.map((r) => r.day));
+  const spendDayMap = new Map(spendDayRows.map((r) => [r.day, r]));
+
+  // 2. Determine the tracking window: from the earliest discretionary
+  //    transaction date through today.
+  const today = new Date();
+  const todayStr = ymd(today);
+
+  let firstTrackedDate: string | null = null;
+  if (spendDayRows.length > 0) {
+    const sorted = spendDayRows.map((r) => r.day).sort();
+    // Start tracking the day BEFORE the first spend, so the first no-spend
+    // streak can include that boundary if it was genuinely no-spend.
+    firstTrackedDate = sorted[0];
+  }
+
+  // 3. Build a per-day map for the last 120 days (enough for 90-day stats + strip).
+  //    We walk day-by-day from today backwards so no-spend gaps are explicit.
+  const lookbackDays = 120;
+  const stripDays: StreakDay[] = [];
+  let noSpendLast30 = 0;
+  let noSpendLast90 = 0;
+  const windowStart90 = new Date(today);
+  windowStart90.setDate(windowStart90.getDate() - 89); // inclusive 90 days
+  const windowStart30 = new Date(today);
+  windowStart30.setDate(windowStart30.getDate() - 29); // inclusive 30 days
+
+  for (let i = lookbackDays - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const ds = ymd(d);
+    const spend = spendDayMap.get(ds);
+    const isNoSpend = !spend; // no discretionary spend that day
+    const dow = (d.getDay() + 7) % 7; // 0=Sun..6=Sat (JS already uses this)
+    const day: StreakDay = {
+      date: ds,
+      dow,
+      isNoSpend,
+      txCount: spend?.tx_count ?? 0,
+      total: spend?.total ?? 0,
+    };
+    stripDays.push(day);
+    if (isNoSpend) {
+      if (d >= windowStart30 && d <= today) noSpendLast30++;
+      if (d >= windowStart90 && d <= today) noSpendLast90++;
+    }
+  }
+
+  // 4. Current streak — consecutive no-spend days ending today OR yesterday.
+  //    (If today already has spending, the streak is held by yesterday's run,
+  //     giving the user the rest of today to extend it.)
+  const todayIsNoSpend = !spendDaySet.has(todayStr);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = ymd(yesterday);
+  const yesterdayWasNoSpend = !spendDaySet.has(yesterdayStr);
+
+  const streakAnchor = todayIsNoSpend
+    ? new Date(today)
+    : yesterdayWasNoSpend
+      ? new Date(yesterday)
+      : null;
+
+  let currentStreak = 0;
+  if (streakAnchor) {
+    const cursor = new Date(streakAnchor);
+    while (!spendDaySet.has(ymd(cursor))) {
+      currentStreak++;
+      cursor.setDate(cursor.getDate() - 1);
+    }
+  }
+
+  // 5. Longest streak — walk all tracked days from firstTrackedDate→today,
+  //    counting maximal runs of no-spend days.
+  let longestStreak = 0;
+  let run = 0;
+  if (firstTrackedDate) {
+    const start = new Date(firstTrackedDate + 'T00:00:00');
+    const end = new Date(todayStr + 'T00:00:00');
+    // Cap at 3 years of day-walking to stay cheap.
+    const guard = new Date(start);
+    guard.setFullYear(guard.getFullYear() + 3);
+    const hardEnd = end < guard ? end : guard;
+    const cursor = new Date(start);
+    while (cursor <= hardEnd) {
+      if (!spendDaySet.has(ymd(cursor))) {
+        run++;
+        if (run > longestStreak) longestStreak = run;
+      } else {
+        run = 0;
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  // 6. Day-of-week pattern — from the last 90 days strip.
+  const dowAgg: Record<number, { spendDays: number; noSpendDays: number; totalSpend: number }> = {};
+  for (let i = 0; i < 7; i++) dowAgg[i] = { spendDays: 0, noSpendDays: 0, totalSpend: 0 };
+  for (const d of stripDays) {
+    const dt = new Date(d.date + 'T00:00:00');
+    if (dt >= windowStart90 && dt <= today) {
+      if (d.isNoSpend) dowAgg[d.dow].noSpendDays++;
+      else {
+        dowAgg[d.dow].spendDays++;
+        dowAgg[d.dow].totalSpend += d.total;
+      }
+    }
+  }
+  const dowPattern: DayOfWeekPattern[] = [];
+  for (let i = 0; i < 7; i++) {
+    const a = dowAgg[i];
+    dowPattern.push({
+      dow: i,
+      label: DOW_LABELS[i],
+      spendDays: a.spendDays,
+      noSpendDays: a.noSpendDays,
+      totalSpend: a.totalSpend,
+      avgPerSpendDay: a.spendDays > 0 ? Math.round(a.totalSpend / a.spendDays) : 0,
+    });
+  }
+
+  // 7. Badges
+  const badges: StreakBadge[] = [
+    { id: 'first-step', label: 'First Step', description: '1 no-spend day', icon: '🌱',
+      unlocked: longestStreak >= 1 || currentStreak >= 1 },
+    { id: 'three-peat', label: 'Three-peat', description: '3-day streak', icon: '🔥',
+      unlocked: longestStreak >= 3,
+      progress: { current: Math.min(longestStreak, 3), target: 3 } },
+    { id: 'week-warrior', label: 'Week Warrior', description: '7-day streak', icon: '⚡',
+      unlocked: longestStreak >= 7,
+      progress: { current: Math.min(longestStreak, 7), target: 7 } },
+    { id: 'fortnight', label: 'Fortnight', description: '14-day streak', icon: '🏆',
+      unlocked: longestStreak >= 14,
+      progress: { current: Math.min(longestStreak, 14), target: 14 } },
+    { id: 'month-master', label: 'Month Master', description: '30-day streak', icon: '👑',
+      unlocked: longestStreak >= 30,
+      progress: { current: Math.min(longestStreak, 30), target: 30 } },
+    { id: 'consistent-30', label: 'Consistent', description: '10+ no-spend days in last 30', icon: '📅',
+      unlocked: noSpendLast30 >= 10,
+      progress: { current: Math.min(noSpendLast30, 10), target: 10 } },
+    { id: 'on-fire', label: 'On Fire', description: 'Current streak ≥ 3 days', icon: '🚀',
+      unlocked: currentStreak >= 3,
+      progress: { current: Math.min(currentStreak, 3), target: 3 } },
+  ];
+
+  // 8. Recent no-spend days (last 30, newest first) for drilldown list
+  const recentNoSpendDays = stripDays
+    .filter((d) => d.isNoSpend && new Date(d.date + 'T00:00:00') >= windowStart30)
+    .map((d) => d.date)
+    .reverse();
+
+  // Total tracked days = days between firstTrackedDate and today (inclusive)
+  let totalDaysTracked = 0;
+  if (firstTrackedDate) {
+    const ms = today.getTime() - new Date(firstTrackedDate + 'T00:00:00').getTime();
+    totalDaysTracked = Math.floor(ms / (1000 * 60 * 60 * 24)) + 1;
+  }
+
+  return {
+    currentStreak,
+    longestStreak,
+    todayIsNoSpend,
+    yesterdayWasNoSpend,
+    noSpendLast30,
+    noSpendLast90,
+    totalDaysTracked,
+    firstTrackedDate,
+    recentDays: stripDays.slice(-35),
+    dowPattern,
+    badges,
+    recentNoSpendDays,
+  };
+}
+
+/** Format a Date as YYYY-MM-DD in local time (avoids UTC off-by-one). */
+function ymd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 export function getTransactionStats(periodId: number) {

--- a/src/pages/api/streaks.ts
+++ b/src/pages/api/streaks.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+import { getSpendingStreaks } from '../../lib/db';
+
+export const GET: APIRoute = async () => {
+  const result = getSpendingStreaks();
+  return new Response(JSON.stringify(result), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/transactions-by-date.ts
+++ b/src/pages/api/transactions-by-date.ts
@@ -1,0 +1,19 @@
+import type { APIRoute } from 'astro';
+import { getTransactionsByDate } from '../../lib/db';
+
+// GET /api/transactions-by-date?day=YYYY-MM-DD
+// Returns all transactions whose created_time (or date fallback) falls on that day.
+export const GET: APIRoute = async ({ request }) => {
+  const url = new URL(request.url);
+  const day = url.searchParams.get('day');
+  if (!day || !/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+    return new Response(JSON.stringify({ error: 'Missing or invalid "day" param (expected YYYY-MM-DD)' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const rows = getTransactionsByDate(day);
+  return new Response(JSON.stringify(rows), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/streaks.astro
+++ b/src/pages/streaks.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SpendingStreaks from '../components/SpendingStreaks';
+---
+
+<Layout title="Spending Streaks - Financial Dashboard">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold">🔥 Spending Streaks</h1>
+    <p class="text-slate-500 dark:text-slate-400 text-sm">
+      Gamify your frugality — build no-spend day streaks, earn badges, and spot your spending patterns.
+    </p>
+  </div>
+
+  <SpendingStreaks client:load />
+</Layout>


### PR DESCRIPTION
Closes #74

## What
A new `/streaks` page that turns frugality into a game by tracking consecutive no-spend days. This is the dashboard's first behavioral/motivation feature -- all 23 existing pages are analytical (budgets, forecasts, comparisons), none drive behavior change through gamification.

A no-spend day = a calendar day with zero discretionary spending (cash or credit_expense). Credit-card payments are excluded because they're just moving money between accounts, not real spending.

## Why it matters
No-spend-day streaks are a proven behavior-change pattern in personal finance apps. The DB already has rich `created_time` timestamps (659 transactions with per-day placement), so this required zero schema changes -- it surfaces existing data in a motivating new way.

## Live data preview
Against the live DB, the feature immediately shows:
- Longest streak: 30 days
- 51 no-spend days in the last 90 (55%)
- Sundays are the heaviest spending day (avg 1.5M IDR), user is most disciplined on Fridays
- 5 of 7 badges unlocked

## Features
- Headline cards: current streak, longest streak, no-spend counts (30d/90d) with ratio bar
- 5-week contribution strip (GitHub-style heatmap): green = no-spend, warm colors = spending intensity buckets. Click any day for a drill-down dialog listing that day's transactions.
- Day-of-week pattern (last 90d): spend vs no-spend ratio per weekday + avg spend per spend-day, with actionable "heaviest weekday" / "most disciplined weekday" insights
- 7 achievement badges (First Step, Three-peat, Week Warrior, Fortnight, Month Master, Consistent, On Fire) with progress bars for locked ones
- Recent no-spend days chip list (last 30d)
- "How it works" explainer footer

## Implementation
| File | Change |
|------|--------|
| `src/lib/db.ts` | `getSpendingStreaks()` + `getTransactionsByDate(day)` -- pure SQL pull of discretionary spend days + JS day-walk for streak computation (3yr guard cap) |
| `src/pages/api/streaks.ts` | New endpoint returning the full `StreakResult` |
| `src/pages/api/transactions-by-date.ts` | New endpoint for day drill-down (validates YYYY-MM-DD) |
| `src/components/SpendingStreaks.tsx` | React component -- fetches client-side to avoid the devalue prop serialization pitfall (per `astro-pm2-hydration-fix`) |
| `src/pages/streaks.astro` | New page |
| `src/layouts/Layout.astro` | Nav link (desktop + mobile) |
| `src/components/CommandPalette.tsx` | Cmd+K entry |

## Verification
- Clean build (`rm -rf dist/ .astro/ && npm run build`) -- `SpendingStreaks.BotckZOX.js` generated
- PM2 restarted, no errors in logs
- `GET /streaks` returns 200, island hydrates with `client="load"`
- `GET /api/streaks` returns 200, valid JSON (30-day longest streak, 92 days tracked)
- `GET /api/transactions-by-date?day=2026-06-28` returns 4 transactions
- `GET /api/transactions-by-date?day=2026-06-10` returns `[]` (correctly empty no-spend day)
- `GET /api/transactions-by-date?day=invalid` returns 400 error
- CSS loads 200 on both `/` and `/streaks` (no stale build)

## How to test
1. Visit `http://localhost:4321/streaks`
2. Click any warm-colored day in the strip -- dialog shows that day's transactions
3. Click a green (no-spend) day -- dialog shows "No discretionary spending!"
4. Hover strip cells to see tooltips with amounts
5. Check the day-of-week panel for your heaviest spending day
