### PR TITLE
feat: Savings Rate Tracker — benchmarks, streaks & milestones

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -18,6 +18,7 @@ const ALL_ITEMS: CommandItem[] = [
   { id: 'budget', label: 'Budget Report', description: 'Category budget tracking', icon: '📑', group: 'pages', href: '/budget' },
   { id: 'spending-mix', label: 'Spending Mix', description: 'Recurring vs discretionary breakdown', icon: '🔀', group: 'pages', href: '/spending-mix' },
   { id: 'compare', label: 'Month Comparison', description: 'Compare spending across months', icon: '⚖️', group: 'pages', href: '/compare' },
+  { id: 'savings-rate', label: 'Savings Rate Tracker', description: 'Track savings rate, benchmarks & milestones', icon: '💰', group: 'pages', href: '/savings-rate' },
   { id: 'analytics', label: 'Spending Analytics', description: 'Daily trends and category drill-down', icon: '📈', group: 'pages', href: '/analytics' },
   { id: 'matrix', label: 'Spending Matrix', description: 'Category × period heatmap of all spending', icon: '🔳', group: 'pages', href: '/matrix' },
   { id: 'cashflow', label: 'Cash Flow', description: 'Income vs outcome waterfall', icon: '💸', group: 'pages', href: '/cashflow' },

--- a/src/components/SavingsRateTracker.tsx
+++ b/src/components/SavingsRateTracker.tsx
@@ -1,0 +1,586 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { formatIdr } from '../lib/utils';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Trophy,
+  AlertTriangle,
+  Target,
+  Award,
+  PiggyBank,
+  Flame,
+  Info,
+} from 'lucide-react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
+import { Line, Bar } from 'react-chartjs-2';
+
+ChartJS.register(
+  CategoryScale, LinearScale, PointElement, LineElement, BarElement,
+  Title, Tooltip, Legend, Filler
+);
+
+// ============================================================
+// Data shapes must match SavingsRateResult in src/lib/db.ts.
+// Fetched at runtime from /api/savings-rate (NOT passed as Astro
+// props) to avoid the devalue serialization pitfall.
+// ============================================================
+interface SavingsRatePeriod {
+  period_id: number;
+  month: string;
+  start_date: string;
+  end_date: string;
+  income: number;
+  outcome: number;
+  savings: number;
+  savings_rate: number;
+  is_positive: boolean;
+}
+interface SavingsRateResult {
+  periods: SavingsRatePeriod[];
+  current: SavingsRatePeriod | null;
+  avg_rate: number;
+  median_rate: number;
+  best_rate: number;
+  worst_rate: number;
+  best_month: string | null;
+  worst_month: string | null;
+  positive_count: number;
+  negative_count: number;
+  total_periods: number;
+  consecutive_positive: number;
+  longest_positive_streak: number;
+  total_saved: number;
+  trailing3_avg: number;
+  trailing6_avg: number;
+  trend: 'improving' | 'declining' | 'stable';
+}
+
+// Savings rate benchmark tiers (widely used personal-finance guidelines)
+const BENCHMARKS = [
+  { label: 'Critical', min: -Infinity, max: 0, color: '#ef4444', desc: 'Spending more than you earn' },
+  { label: 'Building', min: 0, max: 10, color: '#f97316', desc: 'Just starting to save' },
+  { label: 'Fair', min: 10, max: 20, color: '#eab308', desc: 'On the right track' },
+  { label: 'Good', min: 20, max: 30, color: '#22c55e', desc: 'Healthy savings habit' },
+  { label: 'Excellent', min: 30, max: 50, color: '#10b981', desc: 'Strong financial position' },
+  { label: 'FIRE-Ready', min: 50, max: Infinity, color: '#06b6d4', desc: 'Aggressive wealth building' },
+];
+
+function getBenchmark(rate: number) {
+  return BENCHMARKS.find((b) => rate >= b.min && rate < b.max) ?? BENCHMARKS[0];
+}
+
+const MILESTONES = [
+  { rate: 10, label: 'First 10%', icon: '🌱', desc: 'You are officially saving!' },
+  { rate: 20, label: '20% Club', icon: '⭐', desc: 'Recommended minimum by financial advisors' },
+  { rate: 30, label: '30% Striver', icon: '💪', desc: 'Strong savings discipline' },
+  { rate: 50, label: '50% Master', icon: '👑', desc: 'FIRE-movement territory' },
+  { rate: 70, label: '70% Legend', icon: '🔥', desc: 'Extreme wealth building' },
+];
+
+export default function SavingsRateTracker() {
+  const [data, setData] = useState<SavingsRateResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [chartView, setChartView] = useState<'rate' | 'amount'>('rate');
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetch('/api/savings-rate')
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d) => { setData(d); setLoading(false); })
+      .catch((e) => { setError(e.message); setLoading(false); });
+  }, []);
+
+  // Chart data — all hooks MUST be before any early return (Rules of Hooks)
+  const rateChartData = useMemo(() => {
+    if (!data || data.periods.length === 0) return null;
+    const labels = data.periods.map((p) => p.month);
+    const rates = data.periods.map((p) => p.savings_rate);
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Savings Rate %',
+          data: rates,
+          borderColor: '#6366f1',
+          backgroundColor: (ctx: any) => {
+            const chart = ctx.chart;
+            const { ctx: c, chartArea } = chart;
+            if (!chartArea) return 'rgba(99,102,241,0.1)';
+            const gradient = c.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+            gradient.addColorStop(0, 'rgba(99,102,241,0.35)');
+            gradient.addColorStop(1, 'rgba(99,102,241,0.02)');
+            return gradient;
+          },
+          fill: true,
+          tension: 0.35,
+          pointRadius: data.periods.length > 20 ? 2 : 4,
+          pointHoverRadius: 7,
+          pointBackgroundColor: rates.map((r) => r >= 0 ? '#22c55e' : '#ef4444'),
+          pointBorderColor: rates.map((r) => r >= 0 ? '#16a34a' : '#dc2626'),
+          borderWidth: 2,
+        },
+      ],
+    };
+  }, [data]);
+
+  const amountChartData = useMemo(() => {
+    if (!data || data.periods.length === 0) return null;
+    const labels = data.periods.map((p) => p.month);
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Income',
+          data: data.periods.map((p) => p.income),
+          backgroundColor: 'rgba(34,197,94,0.7)',
+          borderColor: '#16a34a',
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+        {
+          label: 'Spending',
+          data: data.periods.map((p) => p.outcome),
+          backgroundColor: 'rgba(239,68,68,0.7)',
+          borderColor: '#dc2626',
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+        {
+          label: 'Savings',
+          data: data.periods.map((p) => p.savings),
+          backgroundColor: data.periods.map((p) =>
+            p.savings >= 0 ? 'rgba(99,102,241,0.7)' : 'rgba(234,179,8,0.7)'
+          ),
+          borderColor: data.periods.map((p) => (p.savings >= 0 ? '#4f46e5' : '#ca8a04')),
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+      ],
+    };
+  }, [data]);
+
+  const milestones = useMemo(() => {
+    if (!data) return [];
+    const best = data.best_rate;
+    return MILESTONES.map((m) => ({
+      ...m,
+      achieved: best >= m.rate,
+    }));
+  }, [data]);
+
+  const benchmarkBuckets = useMemo(() => {
+    if (!data || data.periods.length === 0) return [];
+    return BENCHMARKS.map((b) => {
+      const count = data.periods.filter((p) => p.savings_rate >= b.min && p.savings_rate < b.max).length;
+      return { ...b, count, pct: data.total_periods > 0 ? (count / data.total_periods) * 100 : 0 };
+    }).filter((b) => b.count > 0);
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-slate-400">Loading savings rate data…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-red-500">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!data || data.periods.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <PiggyBank className="w-12 h-12 text-slate-300 mb-4" />
+        <h3 className="text-lg font-semibold text-slate-500">No savings data yet</h3>
+        <p className="text-sm text-slate-400 mt-2 max-w-md">
+          You need income records and spending transactions to compute your savings rate.
+          Try running month kickoff or adding income via the settings page.
+        </p>
+      </div>
+    );
+  }
+
+  const current = data.current!;
+  const currentBench = getBenchmark(current.savings_rate);
+  const avgBench = getBenchmark(data.avg_rate);
+
+  const rateChartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false as const,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx: any) => {
+            const idx = ctx.dataIndex;
+            const p = data.periods[idx];
+            return [
+              `Rate: ${p.savings_rate.toFixed(1)}%`,
+              `Income: ${formatIdr(p.income)}`,
+              `Spending: ${formatIdr(p.outcome)}`,
+              `Savings: ${formatIdr(p.savings)}`,
+            ];
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: false,
+        ticks: { callback: (v: any) => `${v}%`, color: '#94a3b8' },
+        grid: { color: 'rgba(148,163,184,0.1)' },
+      },
+      x: { ticks: { color: '#94a3b8', maxRotation: 45 }, grid: { display: false } },
+    },
+    onHover: (_e: any, elements: any[]) => {
+      if (elements.length > 0) setHoveredIdx(elements[0].index);
+      else setHoveredIdx(null);
+    },
+  };
+
+  const amountChartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false as const,
+    plugins: {
+      legend: { position: 'top' as const, labels: { color: '#94a3b8', boxWidth: 12 } },
+      tooltip: {
+        callbacks: { label: (ctx: any) => `${ctx.dataset.label}: ${formatIdr(ctx.parsed.y)}` },
+      },
+    },
+    scales: {
+      y: { ticks: { callback: (v: any) => formatIdrShort(v), color: '#94a3b8' }, grid: { color: 'rgba(148,163,184,0.1)' } },
+      x: { ticks: { color: '#94a3b8', maxRotation: 45 }, grid: { display: false } },
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* === Hero — Current Savings Rate === */}
+      <div className="rounded-2xl p-6 text-white shadow-lg"
+        style={{ background: `linear-gradient(135deg, ${currentBench.color}, ${currentBench.color}dd)` }}>
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <p className="text-white/80 text-sm font-medium uppercase tracking-wide">
+              Current Period · {current.month}
+            </p>
+            <div className="flex items-baseline gap-3 mt-1">
+              <span className="text-5xl font-bold">{current.savings_rate.toFixed(1)}%</span>
+              <span className="text-xl text-white/70">savings rate</span>
+            </div>
+            <p className="text-white/90 text-sm mt-2">{currentBench.desc}</p>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              <span className="px-2 py-1 rounded-lg bg-white/20 backdrop-blur">
+                Saved: {formatIdr(current.savings)}
+              </span>
+              <span className="px-2 py-1 rounded-lg bg-white/20 backdrop-blur">
+                Income: {formatIdr(current.income)}
+              </span>
+              <span className="px-2 py-1 rounded-lg bg-white/20 backdrop-blur">
+                Spending: {formatIdr(current.outcome)}
+              </span>
+            </div>
+          </div>
+          <div className="text-center">
+            <div className="text-6xl mb-1">{getBenchmarkIcon(currentBench.label)}</div>
+            <span className="px-3 py-1 rounded-full bg-white/20 backdrop-blur text-sm font-semibold">
+              {currentBench.label}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* === Trend Banner === */}
+      {data.total_periods >= 3 && (
+        <div className={`flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium ${
+          data.trend === 'improving' ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400' :
+          data.trend === 'declining' ? 'bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-400' :
+          'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+        }`}>
+          {data.trend === 'improving' && <TrendingUp className="w-5 h-5" />}
+          {data.trend === 'declining' && <TrendingDown className="w-5 h-5" />}
+          {data.trend === 'stable' && <Minus className="w-5 h-5" />}
+          <span>
+            Your savings rate is <strong>{data.trend}</strong> —
+            trailing 3-period avg is <strong>{data.trailing3_avg.toFixed(1)}%</strong> vs
+            trailing 6-period avg of <strong>{data.trailing6_avg.toFixed(1)}%</strong>.
+          </span>
+        </div>
+      )}
+
+      {/* === Stat Cards === */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          icon={<Target className="w-5 h-5" />}
+          label="Average Rate"
+          value={`${data.avg_rate.toFixed(1)}%`}
+          subtitle={`Median ${data.median_rate.toFixed(1)}% · ${avgBench.label}`}
+          color="text-indigo-600 dark:text-indigo-400"
+        />
+        <StatCard
+          icon={<Trophy className="w-5 h-5" />}
+          label="Best Month"
+          value={`${data.best_rate.toFixed(1)}%`}
+          subtitle={data.best_month ?? ''}
+          color="text-emerald-600 dark:text-emerald-400"
+        />
+        <StatCard
+          icon={<AlertTriangle className="w-5 h-5" />}
+          label="Worst Month"
+          value={`${data.worst_rate.toFixed(1)}%`}
+          subtitle={data.worst_month ?? ''}
+          color="text-rose-600 dark:text-rose-400"
+        />
+        <StatCard
+          icon={<PiggyBank className="w-5 h-5" />}
+          label="Total Saved"
+          value={formatIdrShort(data.total_saved)}
+          subtitle={`across ${data.total_periods} periods`}
+          color="text-cyan-600 dark:text-cyan-400"
+        />
+      </div>
+
+      {/* === Chart === */}
+      <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-semibold">Savings Rate Over Time</h3>
+          <div className="flex gap-1 p-1 rounded-lg bg-slate-100 dark:bg-slate-700">
+            <button
+              onClick={() => setChartView('rate')}
+              className={`px-3 py-1 text-xs rounded-md transition ${
+                chartView === 'rate' ? 'bg-white dark:bg-slate-600 shadow-sm font-semibold' : 'text-slate-500'
+              }`}
+            >
+              Rate %
+            </button>
+            <button
+              onClick={() => setChartView('amount')}
+              className={`px-3 py-1 text-xs rounded-md transition ${
+                chartView === 'amount' ? 'bg-white dark:bg-slate-600 shadow-sm font-semibold' : 'text-slate-500'
+              }`}
+            >
+              Amounts
+            </button>
+          </div>
+        </div>
+        <div style={{ height: 320 }}>
+          {chartView === 'rate' && rateChartData && <Line data={rateChartData} options={rateChartOptions} />}
+          {chartView === 'amount' && amountChartData && <Bar data={amountChartData} options={amountChartOptions} />}
+        </div>
+        {hoveredIdx !== null && data.periods[hoveredIdx] && (
+          <div className="mt-3 p-3 rounded-lg bg-slate-50 dark:bg-slate-700/50 text-sm">
+            <strong>{data.periods[hoveredIdx].month}</strong>: {data.periods[hoveredIdx].savings_rate.toFixed(1)}% rate ·
+            Saved {formatIdr(data.periods[hoveredIdx].savings)} of {formatIdr(data.periods[hoveredIdx].income)}
+          </div>
+        )}
+      </div>
+
+      {/* === Two-column: Streaks + Benchmarks === */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Streak Card */}
+        <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
+          <div className="flex items-center gap-2 mb-4">
+            <Flame className="w-5 h-5 text-orange-500" />
+            <h3 className="font-semibold">Positive Savings Streaks</h3>
+          </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between p-3 rounded-lg bg-orange-50 dark:bg-orange-950/30">
+              <span className="text-sm font-medium">Current Streak</span>
+              <span className="text-2xl font-bold text-orange-600 dark:text-orange-400">
+                {data.consecutive_positive}
+                <span className="text-sm font-normal ml-1">periods</span>
+              </span>
+            </div>
+            <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-700/50">
+              <span className="text-sm font-medium">Longest Ever</span>
+              <span className="text-2xl font-bold text-slate-700 dark:text-slate-300">
+                {data.longest_positive_streak}
+                <span className="text-sm font-normal ml-1">periods</span>
+              </span>
+            </div>
+            <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-700/50">
+              <span className="text-sm font-medium">Positive vs Negative</span>
+              <span className="text-sm font-semibold">
+                <span className="text-emerald-600 dark:text-emerald-400">{data.positive_count} positive</span>
+                {' / '}
+                <span className="text-rose-600 dark:text-rose-400">{data.negative_count} negative</span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Benchmark Distribution */}
+        <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
+          <div className="flex items-center gap-2 mb-4">
+            <Award className="w-5 h-5 text-indigo-500" />
+            <h3 className="font-semibold">Rate Distribution</h3>
+          </div>
+          <p className="text-xs text-slate-500 mb-3">How often your savings rate lands in each tier</p>
+          <div className="space-y-2">
+            {benchmarkBuckets.map((b) => (
+              <div key={b.label} className="flex items-center gap-3">
+                <div className="w-24 text-xs font-medium" style={{ color: b.color }}>{b.label}</div>
+                <div className="flex-1 h-6 rounded-md bg-slate-100 dark:bg-slate-700 overflow-hidden relative">
+                  <div
+                    className="h-full rounded-md transition-all"
+                    style={{ width: `${b.pct}%`, backgroundColor: b.color }}
+                  />
+                  <span className="absolute inset-0 flex items-center justify-end pr-2 text-xs font-semibold text-slate-700 dark:text-slate-200">
+                    {b.count}× ({b.pct.toFixed(0)}%)
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* === Milestones === */}
+      <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
+        <div className="flex items-center gap-2 mb-4">
+          <Award className="w-5 h-5 text-amber-500" />
+          <h3 className="font-semibold">Savings Milestones</h3>
+          <span className="text-xs text-slate-500 ml-auto">Based on your best rate: {data.best_rate.toFixed(1)}%</span>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+          {milestones.map((m) => (
+            <div
+              key={m.label}
+              className={`p-4 rounded-xl text-center transition ${
+                m.achieved
+                  ? 'bg-gradient-to-br from-amber-50 to-yellow-50 dark:from-amber-950/40 dark:to-yellow-950/40 border-2 border-amber-300 dark:border-amber-700'
+                  : 'bg-slate-50 dark:bg-slate-700/50 border-2 border-transparent opacity-60'
+              }`}
+            >
+              <div className={`text-3xl mb-1 ${m.achieved ? '' : 'grayscale'}`}>{m.icon}</div>
+              <div className={`text-sm font-bold ${m.achieved ? 'text-amber-700 dark:text-amber-400' : 'text-slate-500'}`}>
+                {m.label}
+              </div>
+              <div className="text-[10px] text-slate-400 mt-1 leading-tight">{m.desc}</div>
+              {m.achieved && (
+                <div className="mt-2 text-[10px] font-bold text-emerald-600 dark:text-emerald-400">✓ ACHIEVED</div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* === Per-Period Detail Table === */}
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
+        <div className="p-4 border-b border-slate-200 dark:border-slate-700">
+          <h3 className="font-semibold">Period-by-Period Breakdown</h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-700/50 text-slate-500 dark:text-slate-400">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Period</th>
+                <th className="text-right px-4 py-2 font-medium">Income</th>
+                <th className="text-right px-4 py-2 font-medium">Spending</th>
+                <th className="text-right px-4 py-2 font-medium">Saved</th>
+                <th className="text-right px-4 py-2 font-medium">Rate</th>
+                <th className="text-left px-4 py-2 font-medium">Tier</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...data.periods].reverse().map((p) => {
+                const bench = getBenchmark(p.savings_rate);
+                return (
+                  <tr key={p.period_id} className="border-t border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                    <td className="px-4 py-2 font-medium">{p.month}</td>
+                    <td className="px-4 py-2 text-right text-slate-600 dark:text-slate-300">{formatIdr(p.income)}</td>
+                    <td className="px-4 py-2 text-right text-slate-600 dark:text-slate-300">{formatIdr(p.outcome)}</td>
+                    <td className={`px-4 py-2 text-right font-medium ${p.savings >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
+                      {formatIdr(p.savings)}
+                    </td>
+                    <td className={`px-4 py-2 text-right font-bold ${p.savings_rate >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
+                      {p.savings_rate.toFixed(1)}%
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className="px-2 py-0.5 rounded-full text-xs font-medium text-white"
+                        style={{ backgroundColor: bench.color }}
+                      >
+                        {bench.label}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-2 text-xs text-slate-400 dark:text-slate-500 px-1">
+        <Info className="w-4 h-4 mt-0.5 flex-shrink-0" />
+        <span>
+          Savings Rate = (Income − Spending) / Income × 100. Spending includes cash and credit-card payments (done=1).
+          The FIRE benchmark (50%+) is the threshold recommended by the FIRE (Financial Independence, Retire Early) movement.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Helper components ───────────────────────────────────────────────────────
+
+function StatCard({ icon, label, value, subtitle, color }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  subtitle: string;
+  color: string;
+}) {
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-xl p-4 shadow-sm border border-slate-200 dark:border-slate-700">
+      <div className={`flex items-center gap-2 mb-2 ${color}`}>
+        {icon}
+        <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</span>
+      </div>
+      <div className="text-2xl font-bold text-slate-800 dark:text-slate-100">{value}</div>
+      <div className="text-xs text-slate-400 mt-1">{subtitle}</div>
+    </div>
+  );
+}
+
+function formatIdrShort(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return Math.round(n).toString();
+}
+
+function getBenchmarkIcon(label: string): string {
+  switch (label) {
+    case 'Critical': return '🚨';
+    case 'Building': return '🌱';
+    case 'Fair': return '📈';
+    case 'Good': return '✅';
+    case 'Excellent': return '🌟';
+    case 'FIRE-Ready': return '🔥';
+    default: return '💰';
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -61,6 +61,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
         <a href="/credit-card" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-amber-600 dark:text-amber-400">Credit Card</a>
         <a href="/recommendations" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-indigo-600 dark:text-indigo-400">Recommend</a>
         <a href="/compare" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Compare</a>
+        <a href="/savings-rate" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-emerald-600 dark:text-emerald-400">Savings Rate</a>
         <a href="/analytics" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Analytics</a>
         <a href="/matrix" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
         <a href="/cashflow" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Cash Flow</a>
@@ -92,6 +93,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
           <a href="/credit-card" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-amber-600 dark:text-amber-400">Credit Card</a>
           <a href="/recommendations" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-indigo-600 dark:text-indigo-400">Recommend</a>
           <a href="/compare" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Compare</a>
+          <a href="/savings-rate" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-emerald-600 dark:text-emerald-400">Savings Rate</a>
           <a href="/analytics" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Analytics</a>
           <a href="/matrix" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
           <a href="/cashflow" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Cash Flow</a>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1669,3 +1669,168 @@ export function getRecurringVsDiscretionary(periodId?: number): RecurringBreakdo
 
   return { periods, current, topRecurring };
 }
+
+// ─── Savings Rate Tracker ────────────────────────────────────────────────────
+
+export interface SavingsRatePeriod {
+  period_id: number;
+  month: string;
+  start_date: string;
+  end_date: string;
+  income: number;
+  outcome: number;          // total paid spending (cash + credit_payment)
+  savings: number;          // income - outcome
+  savings_rate: number;     // pct, can be negative
+  is_positive: boolean;
+}
+
+export interface SavingsRateResult {
+  periods: SavingsRatePeriod[];
+  current: SavingsRatePeriod | null;
+  avg_rate: number;
+  median_rate: number;
+  best_rate: number;
+  worst_rate: number;
+  best_month: string | null;
+  worst_month: string | null;
+  positive_count: number;
+  negative_count: number;
+  total_periods: number;
+  consecutive_positive: number;   // current run ending at latest period
+  longest_positive_streak: number;
+  total_saved: number;
+  // Trailing-3 and trailing-6 average rates for trend detection
+  trailing3_avg: number;
+  trailing6_avg: number;
+  trend: 'improving' | 'declining' | 'stable';
+}
+
+/**
+ * Compute per-period savings rate (income − outcome) / income.
+ * Uses the same outcome definition as getMonthlySummary (cash + credit_payment, done=1).
+ */
+export function getSavingsRate(): SavingsRateResult {
+  const periodRows = db.prepare(`
+    SELECT DISTINCT p.id, p.month, p.start_date, p.end_date
+    FROM periods p
+    INNER JOIN transactions t ON t.period_id = p.id
+    ORDER BY p.start_date ASC
+  `).all() as { id: number; month: string; start_date: string; end_date: string }[];
+
+  // Income per period
+  const incomeRows = db.prepare(`
+    SELECT mi.period_id, mi.income, mi.other_income
+    FROM monthly_income mi JOIN periods p ON mi.period_id = p.id
+    ORDER BY p.start_date ASC
+  `).all() as { period_id: number; income: number; other_income: number }[];
+  const incomeMap = new Map<number, number>();
+  for (const r of incomeRows) {
+    incomeMap.set(r.period_id, (r.income || 0) + (r.other_income || 0));
+  }
+
+  // Outcome per period (cash + credit_payment, done=1) — same definition as summary
+  const outcomeRows = db.prepare(`
+    SELECT period_id, SUM(amount) AS outcome
+    FROM transactions
+    WHERE done = 1 AND type IN ('cash', 'credit_payment')
+    GROUP BY period_id
+  `).all() as { period_id: number; outcome: number }[];
+  const outcomeMap = new Map<number, number>();
+  for (const r of outcomeRows) {
+    outcomeMap.set(r.period_id, r.outcome || 0);
+  }
+
+  const periods: SavingsRatePeriod[] = [];
+  for (const p of periodRows) {
+    const income = incomeMap.get(p.id) || 0;
+    const outcome = outcomeMap.get(p.id) || 0;
+    if (income <= 0) continue; // skip periods with no income — can't compute a rate
+    const savings = income - outcome;
+    const rate = (savings / income) * 100;
+    periods.push({
+      period_id: p.id,
+      month: p.month,
+      start_date: p.start_date,
+      end_date: p.end_date,
+      income,
+      outcome,
+      savings,
+      savings_rate: Math.round(rate * 100) / 100,
+      is_positive: savings >= 0,
+    });
+  }
+
+  if (periods.length === 0) {
+    return {
+      periods: [], current: null, avg_rate: 0, median_rate: 0,
+      best_rate: 0, worst_rate: 0, best_month: null, worst_month: null,
+      positive_count: 0, negative_count: 0, total_periods: 0,
+      consecutive_positive: 0, longest_positive_streak: 0, total_saved: 0,
+      trailing3_avg: 0, trailing6_avg: 0, trend: 'stable',
+    };
+  }
+
+  const rates = periods.map((p) => p.savings_rate);
+  const sortedRates = [...rates].sort((a, b) => a - b);
+  const n = rates.length;
+  const avg = rates.reduce((s, r) => s + r, 0) / n;
+  const mid = Math.floor(n / 2);
+  const median = n % 2 === 0 ? (sortedRates[mid - 1] + sortedRates[mid]) / 2 : sortedRates[mid];
+
+  let bestIdx = 0, worstIdx = 0;
+  for (let i = 1; i < n; i++) {
+    if (rates[i] > rates[bestIdx]) bestIdx = i;
+    if (rates[i] < rates[worstIdx]) worstIdx = i;
+  }
+
+  const positive_count = periods.filter((p) => p.is_positive).length;
+  const negative_count = n - positive_count;
+
+  // Consecutive positive streaks (ending at latest period)
+  let consecutive_positive = 0;
+  for (let i = n - 1; i >= 0; i--) {
+    if (periods[i].is_positive) consecutive_positive++;
+    else break;
+  }
+  let longest_positive_streak = 0;
+  let run = 0;
+  for (const p of periods) {
+    if (p.is_positive) { run++; if (run > longest_positive_streak) longest_positive_streak = run; }
+    else run = 0;
+  }
+
+  const total_saved = periods.reduce((s, p) => s + p.savings, 0);
+
+  // Trailing averages
+  const trailing3 = periods.slice(-3).map((p) => p.savings_rate);
+  const trailing6 = periods.slice(-6).map((p) => p.savings_rate);
+  const trailing3_avg = trailing3.reduce((s, r) => s + r, 0) / Math.max(1, trailing3.length);
+  const trailing6_avg = trailing6.reduce((s, r) => s + r, 0) / Math.max(1, trailing6.length);
+
+  let trend: 'improving' | 'declining' | 'stable' = 'stable';
+  if (n >= 3) {
+    const diff = trailing3_avg - trailing6_avg;
+    if (diff > 3) trend = 'improving';
+    else if (diff < -3) trend = 'declining';
+  }
+
+  return {
+    periods,
+    current: periods[periods.length - 1],
+    avg_rate: Math.round(avg * 100) / 100,
+    median_rate: Math.round(median * 100) / 100,
+    best_rate: rates[bestIdx],
+    worst_rate: rates[worstIdx],
+    best_month: periods[bestIdx].month,
+    worst_month: periods[worstIdx].month,
+    positive_count,
+    negative_count,
+    total_periods: n,
+    consecutive_positive,
+    longest_positive_streak,
+    total_saved: Math.round(total_saved),
+    trailing3_avg: Math.round(trailing3_avg * 100) / 100,
+    trailing6_avg: Math.round(trailing6_avg * 100) / 100,
+    trend,
+  };
+}

--- a/src/pages/api/savings-rate.ts
+++ b/src/pages/api/savings-rate.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+import { getSavingsRate } from '../../lib/db';
+
+export const GET: APIRoute = async () => {
+  const result = getSavingsRate();
+  return new Response(JSON.stringify(result), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/savings-rate.astro
+++ b/src/pages/savings-rate.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SavingsRateTracker from '../components/SavingsRateTracker';
+---
+
+<Layout title="Savings Rate Tracker - Financial Dashboard">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold">💰 Savings Rate Tracker</h1>
+    <p class="text-slate-500 dark:text-slate-400 text-sm">
+      Monitor your savings rate over time, benchmark against financial guidelines, and track milestones toward financial independence.
+    </p>
+  </div>
+
+  <SavingsRateTracker client:load />
+</Layout>


### PR DESCRIPTION
## New Feature: Savings Rate Tracker

A new `/savings-rate` page that tracks the savings rate — one of the most fundamental financial health metrics — over time.

### What it shows
- **Hero card**: Current period's savings rate with a color-coded benchmark tier (Critical → Building → Fair → Good → Excellent → FIRE-Ready)
- **Trend banner**: Compares trailing 3-period vs 6-period averages (improving / declining / stable)
- **4 stat cards**: Average rate, best month, worst month, total saved
- **Interactive dual-view chart**: Toggle between rate-over-time line chart and income/spending/savings bar chart
- **Streak tracker**: Current and longest positive-savings streaks, positive/negative ratio
- **Rate distribution**: Histogram showing how often you land in each benchmark tier
- **Gamified milestones**: 10%, 20%, 30%, 50%, 70% badges with unlock states
- **Per-period table**: Full breakdown with tier badges

### Technical
- New `getSavingsRate()` in `src/lib/db.ts` computes all metrics server-side from `monthly_income` + `transactions` (cash + credit_payment, done=1)
- New API: `GET /api/savings-rate`
- Data fetched client-side (`useEffect`) to avoid Astro devalue serialization pitfalls
- Added to nav (desktop + mobile) and Command Palette (⌘K)

### Verification
- ✅ Build passes (clean `rm -rf dist && npm run build`)
- ✅ Page returns HTTP 200
- ✅ CSS loads (HTTP 200, no stale build)
- ✅ API returns 35 periods of real data
- ✅ No PM2 errors

### Test
Visit `http://localhost:4321/savings-rate`