### PR TITLE
feat: Spending Rhythm — behavioral day/time spending analysis

### DIFF
--- a/src/components/SpendingRhythm.tsx
+++ b/src/components/SpendingRhythm.tsx
@@ -1,0 +1,504 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { formatIdr } from '../lib/utils';
+import {
+  Clock,
+  Calendar,
+  TrendingUp,
+  Sun,
+  Moon,
+  Sunrise,
+  Sunset,
+  Zap,
+  Lightbulb,
+} from 'lucide-react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(
+  CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend
+);
+
+// ============================================================
+// Data shapes must match SpendingRhythmResult in src/lib/db.ts.
+// Fetched at runtime from /api/spending-rhythm (NOT passed as
+// Astro props) to avoid the devalue serialization pitfall.
+// ============================================================
+interface RhythmDowStat {
+  dow: number;
+  label: string;
+  shortLabel: string;
+  isWeekend: boolean;
+  txCount: number;
+  totalSpend: number;
+  avgPerTx: number;
+  distinctDays: number;
+  avgPerDay: number;
+  pctOfTotal: number;
+}
+interface RhythmTimeBucket {
+  label: string;
+  rangeLabel: string;
+  txCount: number;
+  totalSpend: number;
+  pctOfTx: number;
+  pctOfSpend: number;
+}
+interface RhythmInsight {
+  icon: string;
+  title: string;
+  detail: string;
+  tone: 'good' | 'neutral' | 'warn';
+}
+interface SpendingRhythmResult {
+  totalTx: number;
+  totalSpend: number;
+  dateRangeStart: string | null;
+  dateRangeEnd: string | null;
+  dowStats: RhythmDowStat[];
+  weekdayVsWeekend: {
+    weekdayTx: number; weekdaySpend: number; weekdayAvgPerDay: number;
+    weekendTx: number; weekendSpend: number; weekendAvgPerDay: number;
+    weekdayPctSpend: number; weekendPctSpend: number;
+  };
+  peakDay: RhythmDowStat | null;
+  quietDay: RhythmDowStat | null;
+  timeBuckets: RhythmTimeBucket[];
+  peakHour: number | null;
+  categoryHeatmap: { category: string; cells: number[] }[];
+  insights: RhythmInsight[];
+}
+
+const TIME_BUCKET_ICONS: Record<string, React.ReactNode> = {
+  'Late Night': <Moon className="w-5 h-5" />,
+  'Morning': <Sunrise className="w-5 h-5" />,
+  'Afternoon': <Sun className="w-5 h-5" />,
+  'Evening': <Sunset className="w-5 h-5" />,
+};
+
+function fmtDateRange(start: string | null, end: string | null): string {
+  if (!start || !end) return 'No data';
+  const fmt = (iso: string) => new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return `${fmt(start)} → ${fmt(end)}`;
+}
+
+function toneClasses(tone: 'good' | 'neutral' | 'warn'): string {
+  if (tone === 'good') return 'border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/30';
+  if (tone === 'warn') return 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30';
+  return 'border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50';
+}
+
+export default function SpendingRhythm() {
+  const [data, setData] = useState<SpendingRhythmResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dowMetric, setDowMetric] = useState<'avgPerDay' | 'totalSpend' | 'txCount'>('avgPerDay');
+
+  useEffect(() => {
+    fetch('/api/spending-rhythm')
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d) => { setData(d); setLoading(false); })
+      .catch((e) => { setError(e.message); setLoading(false); });
+  }, []);
+
+  // ── Chart data — all hooks MUST be before any early return ──
+  const dowChartData = useMemo(() => {
+    if (!data) return null;
+    const stats = data.dowStats;
+    const isWeekendColors = stats.map((s) =>
+      s.isWeekend ? 'rgba(168, 85, 247, 0.7)' : 'rgba(59, 130, 246, 0.7)'
+    );
+    const isWeekendBorders = stats.map((s) =>
+      s.isWeekend ? 'rgba(168, 85, 247, 1)' : 'rgba(59, 130, 246, 1)'
+    );
+    return {
+      labels: stats.map((s) => s.shortLabel),
+      datasets: [
+        {
+          label:
+            dowMetric === 'avgPerDay' ? 'Avg / Day (IDR)'
+            : dowMetric === 'totalSpend' ? 'Total Spend (IDR)'
+            : 'Transaction Count',
+          data: stats.map((s) => (dowMetric === 'txCount' ? s.txCount : dowMetric === 'totalSpend' ? s.totalSpend : s.avgPerDay)),
+          backgroundColor: isWeekendColors,
+          borderColor: isWeekendBorders,
+          borderWidth: 1,
+          borderRadius: 6,
+        },
+      ],
+    };
+  }, [data, dowMetric]);
+
+  const dowChartOptions = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false as const,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx: any) => {
+            const idx = ctx.dataIndex;
+            const s = data?.dowStats[idx];
+            if (!s) return '';
+            if (dowMetric === 'txCount') return `${s.txCount} transactions`;
+            return `${dowMetric === 'avgPerDay' ? 'Avg/day' : 'Total'}: ${formatIdr(ctx.parsed.y)}`;
+          },
+          afterLabel: (ctx: any) => {
+            const idx = ctx.dataIndex;
+            const s = data?.dowStats[idx];
+            if (!s) return '';
+            return [
+              `${s.txCount} transactions`,
+              `${s.distinctDays} distinct days`,
+              `${formatIdr(s.totalSpend)} total`,
+              `${s.pctOfTotal}% of all spend`,
+            ];
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (val: any) =>
+            dowMetric === 'txCount' ? val : formatIdr(val).replace('IDR ', ''),
+        },
+      },
+    },
+  }), [data, dowMetric]);
+
+  // ── Category heatmap helpers ──
+  const heatmapMax = useMemo(() => {
+    if (!data) return 1;
+    return Math.max(1, ...data.categoryHeatmap.flatMap((c) => c.cells));
+  }, [data]);
+
+  function heatColor(value: number): string {
+    if (value === 0) return 'rgba(148, 163, 184, 0.1)'; // slate-400/10
+    const ratio = Math.min(1, value / heatmapMax);
+    // Interpolate from sky-100 → indigo-600
+    if (ratio > 0.75) return 'rgba(67, 56, 202, 0.85)';   // indigo-700
+    if (ratio > 0.5) return 'rgba(79, 70, 229, 0.75)';    // indigo-600
+    if (ratio > 0.25) return 'rgba(99, 102, 241, 0.6)';   // indigo-500
+    if (ratio > 0.1) return 'rgba(129, 140, 248, 0.5)';   // indigo-400
+    return 'rgba(165, 180, 252, 0.4)';                    // indigo-300
+  }
+
+  // ── Early returns AFTER all hooks ──
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-slate-400">
+        <div className="text-center">
+          <div className="inline-block w-8 h-8 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin mb-3"></div>
+          <p className="text-sm">Analyzing your spending rhythm…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 p-6 text-center">
+        <p className="text-rose-600 dark:text-rose-400 font-medium">Failed to load data</p>
+        <p className="text-sm text-slate-500 mt-1">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data || data.totalTx === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-10 text-center">
+        <Calendar className="w-10 h-10 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
+        <p className="text-slate-500 font-medium">No timestamped spending data yet</p>
+        <p className="text-sm text-slate-400 mt-1">
+          Spending Rhythm needs transactions with <code className="text-xs px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-700">created_time</code> data.
+          New transactions added via the dashboard are automatically tracked.
+        </p>
+      </div>
+    );
+  }
+
+  const { weekdayVsWeekend: wv } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Header summary cards ── */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+          <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 mb-1">
+            <Calendar className="w-3.5 h-3.5" /> Transactions
+          </div>
+          <p className="text-2xl font-bold">{data.totalTx}</p>
+          <p className="text-xs text-slate-400 mt-0.5">{fmtDateRange(data.dateRangeStart, data.dateRangeEnd)}</p>
+        </div>
+
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+          <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 mb-1">
+            <TrendingUp className="w-3.5 h-3.5" /> Total Spend
+          </div>
+          <p className="text-2xl font-bold">{formatIdr(data.totalSpend)}</p>
+          <p className="text-xs text-slate-400 mt-0.5">{data.dowStats.length} weekdays tracked</p>
+        </div>
+
+        <div className="rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/30 p-4">
+          <div className="flex items-center gap-2 text-xs text-indigo-600 dark:text-indigo-400 mb-1">
+            <Zap className="w-3.5 h-3.5" /> Peak Day
+          </div>
+          <p className="text-2xl font-bold text-indigo-700 dark:text-indigo-300">{data.peakDay?.label ?? '—'}</p>
+          <p className="text-xs text-indigo-500/70 mt-0.5">{data.peakDay ? `${formatIdr(data.peakDay.avgPerDay)}/day avg` : 'no data'}</p>
+        </div>
+
+        <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/30 p-4">
+          <div className="flex items-center gap-2 text-xs text-emerald-600 dark:text-emerald-400 mb-1">
+            <Clock className="w-3.5 h-3.5" /> Peak Hour
+          </div>
+          <p className="text-2xl font-bold text-emerald-700 dark:text-emerald-300">
+            {data.peakHour !== null
+              ? `${data.peakHour === 0 ? 12 : data.peakHour > 12 ? data.peakHour - 12 : data.peakHour} ${data.peakHour < 12 ? 'AM' : 'PM'}`
+              : '—'}
+          </p>
+          <p className="text-xs text-emerald-500/70 mt-0.5">most active time</p>
+        </div>
+      </div>
+
+      {/* ── Auto-generated insights ── */}
+      {data.insights.length > 0 && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <h3 className="flex items-center gap-2 text-sm font-semibold mb-3">
+            <Lightbulb className="w-4 h-4 text-amber-500" />
+            Behavioral Insights
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {data.insights.map((ins, i) => (
+              <div key={i} className={`rounded-lg border p-3 flex gap-3 ${toneClasses(ins.tone)}`}>
+                <span className="text-xl flex-shrink-0">{ins.icon}</span>
+                <div>
+                  <p className="text-sm font-medium text-slate-800 dark:text-slate-200">{ins.title}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{ins.detail}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Day of week chart ── */}
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <Calendar className="w-4 h-4 text-indigo-500" />
+            Spending by Day of Week
+          </h3>
+          <div className="flex gap-1 text-xs bg-slate-100 dark:bg-slate-700/50 rounded-lg p-1">
+            {([['avgPerDay', 'Avg/Day'], ['totalSpend', 'Total'], ['txCount', 'Count']] as const).map(([key, label]) => (
+              <button
+                key={key}
+                onClick={() => setDowMetric(key)}
+                className={`px-2.5 py-1 rounded-md font-medium transition ${
+                  dowMetric === key
+                    ? 'bg-white dark:bg-slate-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                    : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ height: 280 }}>
+          {dowChartData && <Bar data={dowChartData} options={dowChartOptions} />}
+        </div>
+
+        <div className="flex items-center gap-4 mt-3 text-xs text-slate-400">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded bg-blue-500/70"></span> Weekday
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded bg-purple-500/70"></span> Weekend
+          </span>
+        </div>
+      </div>
+
+      {/* ── Weekday vs Weekend ── */}
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+        <h3 className="flex items-center gap-2 text-sm font-semibold mb-4">
+          <Calendar className="w-4 h-4 text-purple-500" />
+          Weekday vs Weekend
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Weekday */}
+          <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 p-4">
+            <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-3">💼 WEEKDAYS (Mon–Fri)</p>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Total Spend</span>
+                <span className="font-semibold">{formatIdr(wv.weekdaySpend)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Transactions</span>
+                <span className="font-semibold">{wv.weekdayTx}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Avg / Day</span>
+                <span className="font-semibold">{formatIdr(wv.weekdayAvgPerDay)}</span>
+              </div>
+              <div className="pt-2 border-t border-blue-200 dark:border-blue-800">
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-slate-400">Share of spend</span>
+                  <span className="font-medium text-blue-600 dark:text-blue-400">{wv.weekdayPctSpend}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-blue-100 dark:bg-blue-900/40 overflow-hidden">
+                  <div className="h-full bg-blue-500 rounded-full" style={{ width: `${wv.weekdayPctSpend}%` }}></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Weekend */}
+          <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950/30 p-4">
+            <p className="text-xs font-semibold text-purple-600 dark:text-purple-400 mb-3">🎉 WEEKENDS (Sat–Sun)</p>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Total Spend</span>
+                <span className="font-semibold">{formatIdr(wv.weekendSpend)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Transactions</span>
+                <span className="font-semibold">{wv.weekendTx}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500 dark:text-slate-400">Avg / Day</span>
+                <span className="font-semibold">{formatIdr(wv.weekendAvgPerDay)}</span>
+              </div>
+              <div className="pt-2 border-t border-purple-200 dark:border-purple-800">
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-slate-400">Share of spend</span>
+                  <span className="font-medium text-purple-600 dark:text-purple-400">{wv.weekendPctSpend}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-purple-100 dark:bg-purple-900/40 overflow-hidden">
+                  <div className="h-full bg-purple-500 rounded-full" style={{ width: `${wv.weekendPctSpend}%` }}></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Time of day distribution ── */}
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+        <h3 className="flex items-center gap-2 text-sm font-semibold mb-4">
+          <Clock className="w-4 h-4 text-emerald-500" />
+          Time of Day Distribution
+        </h3>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          {data.timeBuckets.map((bucket) => (
+            <div
+              key={bucket.label}
+              className={`rounded-lg border p-4 ${
+                bucket.label === 'Late Night' ? 'border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/30'
+                : bucket.label === 'Morning' ? 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30'
+                : bucket.label === 'Afternoon' ? 'border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/30'
+                : 'border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-950/30'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-2">
+                {TIME_BUCKET_ICONS[bucket.label]}
+                <span className="text-xs text-slate-400">{bucket.rangeLabel}</span>
+              </div>
+              <p className="text-sm font-semibold text-slate-700 dark:text-slate-300">{bucket.label}</p>
+              <p className="text-lg font-bold mt-1">{bucket.txCount}</p>
+              <p className="text-xs text-slate-400">transactions · {bucket.pctOfTx}%</p>
+              <div className="mt-2 h-1.5 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${
+                    bucket.label === 'Late Night' ? 'bg-indigo-400'
+                    : bucket.label === 'Morning' ? 'bg-amber-400'
+                    : bucket.label === 'Afternoon' ? 'bg-orange-400'
+                    : 'bg-violet-400'
+                  }`}
+                  style={{ width: `${bucket.pctOfTx}%` }}
+                ></div>
+              </div>
+              <p className="text-xs text-slate-400 mt-2">{formatIdr(bucket.totalSpend)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Category × Weekday heatmap ── */}
+      {data.categoryHeatmap.length > 0 && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <h3 className="flex items-center gap-2 text-sm font-semibold mb-4">
+            <TrendingUp className="w-4 h-4 text-indigo-500" />
+            Category × Weekday Heatmap
+          </h3>
+          <p className="text-xs text-slate-400 mb-3">Spending intensity by category across weekdays. Darker = more spending.</p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr>
+                  <th className="text-left py-2 pr-3 text-slate-400 font-medium">Category</th>
+                  {data.dowStats.map((s) => (
+                    <th
+                      key={s.dow}
+                      className={`px-1 py-2 text-center font-medium ${s.isWeekend ? 'text-purple-500' : 'text-slate-400'}`}
+                    >
+                      {s.shortLabel}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.categoryHeatmap.map((row) => (
+                  <tr key={row.category}>
+                    <td className="py-1 pr-3 text-slate-600 dark:text-slate-300 font-medium whitespace-nowrap">
+                      {row.category}
+                    </td>
+                    {row.cells.map((val, idx) => (
+                      <td key={idx} className="px-1 py-1 text-center">
+                        <div
+                          className="rounded-md flex items-center justify-center h-8 text-[10px] font-medium transition hover:scale-105"
+                          style={{
+                            backgroundColor: heatColor(val),
+                            color: val / heatmapMax > 0.5 ? 'white' : undefined,
+                          }}
+                          title={`${row.category} · ${data.dowStats[idx].label}: ${formatIdr(val)}`}
+                        >
+                          {val > 0 ? (val / 1_000_000).toFixed(val >= 1_000_000 ? 1 : 2) + 'M' : ''}
+                        </div>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center justify-end gap-2 mt-3 text-xs text-slate-400">
+            <span>Less</span>
+            <div className="flex gap-0.5">
+              <span className="inline-block w-4 h-3 rounded-sm" style={{ backgroundColor: heatColor(0) }}></span>
+              <span className="inline-block w-4 h-3 rounded-sm" style={{ backgroundColor: heatColor(heatmapMax * 0.15) }}></span>
+              <span className="inline-block w-4 h-3 rounded-sm" style={{ backgroundColor: heatColor(heatmapMax * 0.35) }}></span>
+              <span className="inline-block w-4 h-3 rounded-sm" style={{ backgroundColor: heatColor(heatmapMax * 0.6) }}></span>
+              <span className="inline-block w-4 h-3 rounded-sm" style={{ backgroundColor: heatColor(heatmapMax) }}></span>
+            </div>
+            <span>More</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,6 +66,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
         <a href="/matrix" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
         <a href="/cashflow" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Cash Flow</a>
         <a href="/calendar" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Calendar</a>
+        <a href="/spending-rhythm" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-indigo-600 dark:text-indigo-400">Rhythm</a>
         <a href="/streaks" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-orange-600 dark:text-orange-400">Streaks 🔥</a>
         <a href="/merchants" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600 text-sky-600 dark:text-sky-400">Merchants</a>
         <a href="/goals" class="nav-link px-3 py-1.5 rounded-lg text-sm font-medium transition hover:bg-slate-200 dark:hover:bg-slate-600">Goals</a>
@@ -98,6 +99,7 @@ const { title = 'Financial Dashboard' } = Astro.props;
           <a href="/matrix" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-fuchsia-600 dark:text-fuchsia-400">Matrix</a>
           <a href="/cashflow" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Cash Flow</a>
           <a href="/calendar" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Calendar</a>
+          <a href="/spending-rhythm" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-indigo-600 dark:text-indigo-400">Rhythm</a>
           <a href="/streaks" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-orange-600 dark:text-orange-400">Streaks 🔥</a>
           <a href="/merchants" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700 text-sky-600 dark:text-sky-400">Merchants</a>
           <a href="/goals" class="nav-link px-3 py-2.5 rounded-lg text-sm font-medium text-center transition hover:bg-slate-100 dark:hover:bg-slate-700">Goals</a>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1834,3 +1834,310 @@ export function getSavingsRate(): SavingsRateResult {
     trend,
   };
 }
+
+// ============================================================
+// Spending Rhythm — behavioral day-of-week / time-of-day analysis
+// Uses created_time to reveal WHEN you spend (not just how much).
+// Aggregation is done in JS (not SQL strftime) because created_time
+// has mixed formats (ISO 8601 AND human-readable) that new Date()
+// handles but SQLite strftime() cannot.
+// ============================================================
+
+export interface RhythmDowStat {
+  dow: number;            // 0=Sun .. 6=Sat
+  label: string;          // "Sunday" ... "Saturday"
+  shortLabel: string;     // "Sun" ... "Sat"
+  isWeekend: boolean;
+  txCount: number;
+  totalSpend: number;
+  avgPerTx: number;       // average amount per transaction
+  distinctDays: number;   // how many distinct calendar days had spending on this weekday
+  avgPerDay: number;      // totalSpend / distinctDays
+  pctOfTotal: number;     // share of total spending
+}
+
+export interface RhythmTimeBucket {
+  label: string;          // "Late Night", "Morning", etc.
+  rangeLabel: string;     // "12–5am"
+  txCount: number;
+  totalSpend: number;
+  pctOfTx: number;        // share of transaction count
+  pctOfSpend: number;     // share of total spend
+}
+
+export interface RhythmCategoryCell {
+  category: string;
+  dow: number;            // 0=Sun .. 6=Sat
+  total: number;
+  count: number;
+}
+
+export interface RhythmInsight {
+  icon: string;
+  title: string;
+  detail: string;
+  tone: 'good' | 'neutral' | 'warn';
+}
+
+export interface SpendingRhythmResult {
+  // overall
+  totalTx: number;
+  totalSpend: number;
+  dateRangeStart: string | null;   // ISO of earliest tx
+  dateRangeEnd: string | null;
+  // day of week
+  dowStats: RhythmDowStat[];       // 7 entries, ordered Mon-first (dow 1..6, 0)
+  weekdayVsWeekend: {
+    weekdayTx: number; weekdaySpend: number; weekdayAvgPerDay: number;
+    weekendTx: number; weekendSpend: number; weekendAvgPerDay: number;
+    weekdayPctSpend: number; weekendPctSpend: number;
+  };
+  peakDay: RhythmDowStat | null;    // highest avgPerDay
+  quietDay: RhythmDowStat | null;   // lowest avgPerDay (among days with data)
+  // time of day
+  timeBuckets: RhythmTimeBucket[];  // 4 entries
+  peakHour: number | null;          // 0-23
+  // category x dow heatmap (top categories only)
+  categoryHeatmap: { category: string; cells: number[] }[]; // cells[0..6] = total per dow
+  // insights
+  insights: RhythmInsight[];
+}
+
+const RHYTHM_DOW_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const RHYTHM_DOW_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function parseCreatedTimeSafe(raw: string | null | undefined): Date | null {
+  if (!raw || raw.length < 5) return null;
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+export function getSpendingRhythm(): SpendingRhythmResult {
+  // Pull all spending transactions with created_time.
+  // Exclude only credit_payment (internal money movement) — same convention as
+  // spending streaks. Keep cash + credit_expense.
+  const rows = db.prepare(`
+    SELECT id, title, category, amount, type, created_time
+    FROM transactions
+    WHERE done = 1
+      AND type IN ('cash', 'credit_expense')
+      AND created_time IS NOT NULL
+      AND amount > 0
+  `).all() as any[];
+
+  // Accumulators
+  const dowTxCount = new Array(7).fill(0);
+  const dowTotal = new Array(7).fill(0);
+  const dowDays = Array.from({ length: 7 }, () => new Set<string>());
+
+  const hourTxCount = new Array(24).fill(0);
+  const hourTotal = new Array(24).fill(0);
+
+  // category x dow → { total, count }
+  const catDowMap = new Map<string, { total: number; count: number; dowTotals: number[]; dowCounts: number[] }>();
+
+  let minDate: Date | null = null;
+  let maxDate: Date | null = null;
+  let totalSpend = 0;
+
+  for (const r of rows) {
+    const d = parseCreatedTimeSafe(r.created_time);
+    if (!d) continue;
+    const dow = d.getDay();       // 0-6
+    const hour = d.getHours();    // 0-23
+    const dayKey = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+
+    dowTxCount[dow]++;
+    dowTotal[dow] += r.amount;
+    dowDays[dow].add(dayKey);
+
+    hourTxCount[hour]++;
+    hourTotal[hour] += r.amount;
+
+    const cat = r.category || 'Unknown';
+    if (!catDowMap.has(cat)) {
+      catDowMap.set(cat, { total: 0, count: 0, dowTotals: new Array(7).fill(0), dowCounts: new Array(7).fill(0) });
+    }
+    const ce = catDowMap.get(cat)!;
+    ce.total += r.amount;
+    ce.count++;
+    ce.dowTotals[dow] += r.amount;
+    ce.dowCounts[dow]++;
+
+    if (!minDate || d < minDate) minDate = d;
+    if (!maxDate || d > maxDate) maxDate = d;
+    totalSpend += r.amount;
+  }
+
+  // Build dowStats (order: Mon, Tue, Wed, Thu, Fri, Sat, Sun → display order)
+  const order = [1, 2, 3, 4, 5, 6, 0];
+  const dowStats: RhythmDowStat[] = order.map((dow) => {
+    const distinctDays = dowDays[dow].size;
+    const total = dowTotal[dow];
+    return {
+      dow,
+      label: RHYTHM_DOW_FULL[dow],
+      shortLabel: RHYTHM_DOW_SHORT[dow],
+      isWeekend: dow === 0 || dow === 6,
+      txCount: dowTxCount[dow],
+      totalSpend: Math.round(total),
+      avgPerTx: dowTxCount[dow] > 0 ? Math.round(total / dowTxCount[dow]) : 0,
+      distinctDays,
+      avgPerDay: distinctDays > 0 ? Math.round(total / distinctDays) : 0,
+      pctOfTotal: totalSpend > 0 ? Number(((total / totalSpend) * 100).toFixed(1)) : 0,
+    };
+  });
+
+  // Weekday vs weekend
+  const weekdayDows = [1, 2, 3, 4, 5];
+  const weekendDows = [0, 6];
+  const sumReducer = (arr: number[], sel: number[]) => sel.reduce((s, d) => s + arr[d], 0);
+  const weekdayTx = sumReducer(dowTxCount, weekdayDows);
+  const weekendTx = sumReducer(dowTxCount, weekendDows);
+  const weekdaySpend = sumReducer(dowTotal, weekdayDows);
+  const weekendSpend = sumReducer(dowTotal, weekendDows);
+  const weekdayDistinct = weekdayDows.reduce((s, d) => s + dowDays[d].size, 0);
+  const weekendDistinct = weekendDows.reduce((s, d) => s + dowDays[d].size, 0);
+
+  // Peak / quiet day
+  const daysWithData = dowStats.filter((s) => s.distinctDays > 0);
+  let peakDay: RhythmDowStat | null = null;
+  let quietDay: RhythmDowStat | null = null;
+  if (daysWithData.length > 0) {
+    peakDay = daysWithData.reduce((best, s) => (s.avgPerDay > best.avgPerDay ? s : best));
+    quietDay = daysWithData.reduce((worst, s) => (s.avgPerDay < worst.avgPerDay ? s : worst));
+  }
+
+  // Time buckets: Late Night (0-5), Morning (6-11), Afternoon (12-17), Evening (18-23)
+  const bucketDefs = [
+    { label: 'Late Night', rangeLabel: '12–6 AM', hours: [0, 1, 2, 3, 4, 5], icon: '🌙' },
+    { label: 'Morning', rangeLabel: '6 AM–12 PM', hours: [6, 7, 8, 9, 10, 11], icon: '🌅' },
+    { label: 'Afternoon', rangeLabel: '12–6 PM', hours: [12, 13, 14, 15, 16, 17], icon: '☀️' },
+    { label: 'Evening', rangeLabel: '6 PM–12 AM', hours: [18, 19, 20, 21, 22, 23], icon: '🌆' },
+  ];
+  const totalTxWithHour = hourTxCount.reduce((s, c) => s + c, 0);
+  const totalSpendHour = hourTotal.reduce((s, c) => s + c, 0);
+  const timeBuckets: RhythmTimeBucket[] = bucketDefs.map((b) => {
+    const txCount = b.hours.reduce((s, h) => s + hourTxCount[h], 0);
+    const spend = b.hours.reduce((s, h) => s + hourTotal[h], 0);
+    return {
+      label: b.label,
+      rangeLabel: b.rangeLabel,
+      txCount,
+      totalSpend: Math.round(spend),
+      pctOfTx: totalTxWithHour > 0 ? Number(((txCount / totalTxWithHour) * 100).toFixed(1)) : 0,
+      pctOfSpend: totalSpendHour > 0 ? Number(((spend / totalSpendHour) * 100).toFixed(1)) : 0,
+    };
+  });
+
+  // Peak hour
+  let peakHour: number | null = null;
+  let peakHourCount = 0;
+  for (let h = 0; h < 24; h++) {
+    if (hourTxCount[h] > peakHourCount) { peakHourCount = hourTxCount[h]; peakHour = h; }
+  }
+
+  // Category x dow heatmap — top 8 categories by total
+  const topCats = [...catDowMap.entries()].sort((a, b) => b[1].total - a[1].total).slice(0, 8);
+  const categoryHeatmap = topCats.map(([category, ce]) => ({
+    category,
+    cells: order.map((dow) => Math.round(ce.dowTotals[dow])),
+  }));
+
+  // ── Generate insights ──
+  const insights: RhythmInsight[] = [];
+
+  if (peakDay && quietDay && peakDay.dow !== quietDay.dow && quietDay.avgPerDay > 0) {
+    const ratio = peakDay.avgPerDay / quietDay.avgPerDay;
+    insights.push({
+      icon: ratio >= 2 ? '⚡' : '📊',
+      title: `${peakDay.label}s are your biggest spending day`,
+      detail: `You spend ${ratio.toFixed(1)}× more on ${peakDay.label.toLowerCase()}s (${formatIdrInline(peakDay.avgPerDay)}/day) than ${quietDay.label.toLowerCase()}s (${formatIdrInline(quietDay.avgPerDay)}/day).`,
+      tone: ratio >= 3 ? 'warn' : 'neutral',
+    });
+  }
+
+  if (weekendDistinct > 0 && weekdayDistinct > 0) {
+    const wkdAvgPerDay = weekdaySpend / weekdayDistinct;
+    const wkeAvgPerDay = weekendSpend / weekendDistinct;
+    if (wkeAvgPerDay > wkdAvgPerDay * 1.25) {
+      insights.push({
+        icon: '🎉',
+        title: 'Weekends drain your wallet',
+        detail: `Per-day weekend spending (${formatIdrInline(wkeAvgPerDay)}) is ${(wkeAvgPerDay / Math.max(1, wkdAvgPerDay)).toFixed(1)}× your weekday average (${formatIdrInline(wkdAvgPerDay)}).`,
+        tone: 'warn',
+      });
+    } else if (wkdAvgPerDay > wkeAvgPerDay * 1.25) {
+      insights.push({
+        icon: '💼',
+        title: 'You spend more on weekdays',
+        detail: `Weekday spending (${formatIdrInline(wkdAvgPerDay)}/day) exceeds weekends (${formatIdrInline(wkeAvgPerDay)}/day) — likely commuting and work-day expenses.`,
+        tone: 'neutral',
+      });
+    }
+  }
+
+  if (peakHour !== null) {
+    const peakBucket = bucketDefs.find((b) => b.hours.includes(peakHour!));
+    insights.push({
+      icon: peakBucket?.icon ?? '🕒',
+      title: `Peak spending hour: ${formatHour(peakHour)}`,
+      detail: `Most transactions happen around ${formatHour(peakHour)} (${peakHourCount} transactions). ${peakBucket ? peakBucket.label + ' is your most active time window.' : ''}`,
+      tone: 'neutral',
+    });
+  }
+
+  // Find the dominant time bucket
+  const dominantBucket = [...timeBuckets].sort((a, b) => b.txCount - a.txCount)[0];
+  if (dominantBucket && dominantBucket.pctOfTx > 50) {
+    insights.push({
+      icon: dominantBucket.label === 'Late Night' ? '🌙' : dominantBucket.label === 'Morning' ? '🌅' : dominantBucket.label === 'Afternoon' ? '☀️' : '🌆',
+      title: `${dominantBucket.label} spender`,
+      detail: `${dominantBucket.pctOfTx}% of your transactions happen in the ${dominantBucket.label.toLowerCase()} (${dominantBucket.rangeLabel}).`,
+      tone: dominantBucket.label === 'Late Night' ? 'warn' : 'neutral',
+    });
+  }
+
+  // No-spend day: if any weekday has 0 distinct days (never spent on that weekday)
+  const neverSpentDays = dowStats.filter((s) => s.distinctDays === 0);
+  if (neverSpentDays.length > 0) {
+    insights.push({
+      icon: '🛡️',
+      title: `You've never spent on a ${neverSpentDays.map((d) => d.label).join(' or ')}`,
+      detail: `Across ${rows.length} tracked transactions, no spending has ever landed on a ${neverSpentDays[0].label}.`,
+      tone: 'good',
+    });
+  }
+
+  return {
+    totalTx: rows.length,
+    totalSpend: Math.round(totalSpend),
+    dateRangeStart: minDate ? minDate.toISOString() : null,
+    dateRangeEnd: maxDate ? maxDate.toISOString() : null,
+    dowStats,
+    weekdayVsWeekend: {
+      weekdayTx, weekdaySpend: Math.round(weekdaySpend),
+      weekendTx, weekendSpend: Math.round(weekendSpend),
+      weekdayAvgPerDay: weekdayDistinct > 0 ? Math.round(weekdaySpend / weekdayDistinct) : 0,
+      weekendAvgPerDay: weekendDistinct > 0 ? Math.round(weekendSpend / weekendDistinct) : 0,
+      weekdayPctSpend: totalSpend > 0 ? Number(((weekdaySpend / totalSpend) * 100).toFixed(1)) : 0,
+      weekendPctSpend: totalSpend > 0 ? Number(((weekendSpend / totalSpend) * 100).toFixed(1)) : 0,
+    },
+    peakDay,
+    quietDay,
+    timeBuckets,
+    peakHour,
+    categoryHeatmap,
+    insights,
+  };
+}
+
+function formatIdrInline(n: number): string {
+  return 'IDR ' + Math.round(n).toLocaleString('id-ID');
+}
+
+function formatHour(h: number): string {
+  const period = h < 12 ? 'AM' : 'PM';
+  const hr = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${hr} ${period}`;
+}

--- a/src/pages/api/spending-rhythm.ts
+++ b/src/pages/api/spending-rhythm.ts
@@ -1,0 +1,9 @@
+import type { APIRoute } from 'astro';
+import { getSpendingRhythm } from '../../lib/db';
+
+export const GET: APIRoute = async () => {
+  const result = getSpendingRhythm();
+  return new Response(JSON.stringify(result), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/spending-rhythm.astro
+++ b/src/pages/spending-rhythm.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SpendingRhythm from '../components/SpendingRhythm';
+---
+
+<Layout title="Spending Rhythm - Financial Dashboard">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold">🕐 Spending Rhythm</h1>
+    <p class="text-slate-500 dark:text-slate-400 text-sm">
+      Discover <em>when</em> you spend money — behavioral patterns by day of week, weekday vs weekend, and time of day.
+    </p>
+  </div>
+
+  <SpendingRhythm client:load />
+</Layout>


### PR DESCRIPTION
## Summary
New **Spending Rhythm** page at `/spending-rhythm` that reveals *when* you spend money — behavioral patterns by day-of-week and time-of-day. Closes #80.

## Why
The dashboard has 28 pages analyzing _what_ and _how much_ you spend, but nothing about **when**. The `created_time` field on 229 spending transactions captures real behavioral data that was underutilized (only the heatmap calendar used it).

## What's New
- **Day-of-week bar chart** — toggle between avg/day, total spend, and transaction count; weekdays (blue) vs weekends (purple) color-coded
- **Weekday vs Weekend card** — side-by-side comparison with totals, avg/day, and share-of-spend progress bars
- **Peak Day & Peak Hour callouts** — at-a-glance summary cards
- **Time-of-day distribution** — Late Night / Morning / Afternoon / Evening buckets with transaction counts and spend
- **Category × Weekday heatmap** — top 8 categories across 7 weekdays, color-intensity cells revealing which categories spike on which days
- **Auto-generated insights** — e.g. "⚡ Mondays are your biggest spending day" (3.2× more than Thursdays), "☀️ Peak spending hour: 1 PM"

## Real Data Results
From the live DB (229 spending transactions, Mar–Jul 2026):
- **Peak day:** Monday (IDR 1,826,708/day avg)
- **Quiet day:** Thursday (IDR 578,762/day avg) — **3.2× difference**
- **Peak hour:** 1 PM
- **Time pattern:** Afternoon is most active (39.7% of transactions)
- **Weekday vs weekend:** 76.2% of spend on weekdays

## Technical Notes
- **`getSpendingRhythm()` in db.ts** — aggregation done in JavaScript, not SQL `strftime()`. This is important because `created_time` has **mixed formats** (161 ISO 8601 + 80 human-readable like "March 31, 2026 4:15 PM"). `new Date()` handles both; SQLite's `strftime()` silently drops the 80 non-ISO records (this is a latent bug in the existing `getDayOfWeekSpending()` function).
- **Read-only feature** — no schema changes, no DB writes, no migrations
- **Client-side data fetch** via `/api/spending-rhythm` (avoids the devalue serialization pitfall documented in skills)
- **Rules of Hooks compliant** — all hooks called before early returns
- **Chart.js resize bug prevention** — `maintainAspectRatio: false` + `animation: false` + fixed 280px container height

## Files Changed
| File | Change |
|------|--------|
| `src/lib/db.ts` | Added `getSpendingRhythm()` + interfaces (~310 lines, additive) |
| `src/pages/api/spending-rhythm.ts` | New API endpoint (read-only) |
| `src/components/SpendingRhythm.tsx` | New React island with Chart.js + heatmap |
| `src/pages/spending-rhythm.astro` | New page |
| `src/layouts/Layout.astro` | Nav link (desktop + mobile) |

## How to Test
1. Visit http://localhost:4321/spending-rhythm
2. Toggle the Avg/Day · Total · Count buttons on the day-of-week chart
3. Hover bars to see detailed tooltips (transaction count, distinct days, % of total)
4. Check the insights cards at the top for auto-generated observations
5. Scroll to the Category × Weekday heatmap — hover cells for exact amounts
