### PR TITLE
feat: add day-of-month field to recurring transactions

### DIFF
--- a/src/components/RecurringManager.tsx
+++ b/src/components/RecurringManager.tsx
@@ -32,6 +32,8 @@ const TYPE_OPTIONS = [
   { value: 'credit_payment', label: 'Credit Payment' },
 ];
 
+const defaultDay = () => "21";
+
 export default function RecurringManager() {
   const { confirm: confirmAction } = useConfirm();
   const [recurring, setRecurring] = useState<RecurringTransaction[]>([]);
@@ -51,6 +53,7 @@ export default function RecurringManager() {
     payment_method: string;
     done: boolean;
     end_date: string;
+    created_at: string;
   }>({
     title: '',
     category: '',
@@ -59,6 +62,7 @@ export default function RecurringManager() {
     payment_method: 'Cash',
     done: false,
     end_date: '',
+    created_at: defaultDay(),
   });
 
   useEffect(() => {
@@ -100,6 +104,7 @@ export default function RecurringManager() {
         done: editForm.done,
         active: editForm.active,
         end_date: editForm.end_date || null,
+        created_at: editForm.created_at || defaultDay(),
       });
       setEditingId(null);
       setEditForm({});
@@ -148,8 +153,9 @@ export default function RecurringManager() {
         done: addForm.done,
         active: true,
         end_date: addForm.end_date || null,
+        created_at: addForm.created_at || defaultDay(),
       });
-      setAddForm({ title: '', category: '', amount: '', type: 'cash', payment_method: 'Cash', done: false, end_date: '' });
+      setAddForm({ title: '', category: '', amount: '', type: 'cash', payment_method: 'Cash', done: false, end_date: '', created_at: defaultDay() });
       setIsAdding(false);
       setError('');
       await loadData();
@@ -255,6 +261,17 @@ export default function RecurringManager() {
                 />
                 <p className="text-xs text-slate-400">Stop auto-adding after this month (e.g., last installment)</p>
               </div>
+              <div className="space-y-1.5">
+                <Label>Tgl Transaksi</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={28}
+                  value={addForm.created_at}
+                  onChange={(e) => setAddForm((p) => ({ ...p, created_at: e.target.value }))}
+                />
+                <p className="text-xs text-slate-400">Tanggal transaksi muncul tiap bulan (1-28, default: hari ini)</p>
+              </div>
             </div>
             <div className="flex justify-end">
               <Button size="sm" onClick={handleAdd}>Save Recurring</Button>
@@ -272,6 +289,7 @@ export default function RecurringManager() {
                 <TableHead className="text-right">Amount</TableHead>
                 <TableHead>Type</TableHead>
                 <TableHead>End Date</TableHead>
+                <TableHead>Tgl</TableHead>
                 <TableHead>Paid</TableHead>
                 <TableHead className="w-32"></TableHead>
               </TableRow>
@@ -279,11 +297,11 @@ export default function RecurringManager() {
             <TableBody>
               {loading ? (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center text-muted-foreground py-6">Loading...</TableCell>
+                  <TableCell colSpan={9} className="text-center text-muted-foreground py-6">Loading...</TableCell>
                 </TableRow>
               ) : recurring.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center text-muted-foreground py-6">
+                  <TableCell colSpan={9} className="text-center text-muted-foreground py-6">
                     No recurring transactions yet. Add one above.
                   </TableCell>
                 </TableRow>
@@ -354,6 +372,16 @@ export default function RecurringManager() {
                           />
                         </TableCell>
                         <TableCell>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={28}
+                            value={editForm.created_at ?? defaultDay()}
+                            onChange={(e) => setEditForm((p) => ({ ...p, created_at: e.target.value }))}
+                            className="h-8 text-xs w-16"
+                          />
+                        </TableCell>
+                        <TableCell>
                           <Checkbox
                             checked={!!editForm.done}
                             onCheckedChange={(v) => setEditForm((p) => ({ ...p, done: !!v }))}
@@ -384,6 +412,9 @@ export default function RecurringManager() {
                       </TableCell>
                       <TableCell className="text-xs text-slate-400">
                         {item.end_date || '—'}
+                      </TableCell>
+                      <TableCell className="text-xs text-slate-400">
+                        {item.created_at || '—'}
                       </TableCell>
                       <TableCell>
                         {item.done ? (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -168,7 +168,7 @@ export async function fetchRecurringTransactions(): Promise<RecurringTransaction
   return res.json();
 }
 
-export async function createRecurringTransaction(tx: Omit<RecurringTransaction, 'id' | 'created_at'>): Promise<RecurringTransaction> {
+export async function createRecurringTransaction(tx: Omit<RecurringTransaction, 'id'>): Promise<RecurringTransaction> {
   const res = await fetch('/api/recurring', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -177,7 +177,7 @@ export async function createRecurringTransaction(tx: Omit<RecurringTransaction, 
   return res.json();
 }
 
-export async function updateRecurringTransactionApi(id: number, tx: Partial<Omit<RecurringTransaction, 'id' | 'created_at'>>): Promise<void> {
+export async function updateRecurringTransactionApi(id: number, tx: Partial<Omit<RecurringTransaction, 'id'>>): Promise<void> {
   await fetch(`/api/recurring/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -116,6 +116,7 @@ export function initSchema() {
   // Migrations for columns added after initial schema
   try { db.exec(`ALTER TABLE transactions ADD COLUMN notes TEXT DEFAULT ''`); } catch (_) { /* already exists */ }
   try { db.exec('ALTER TABLE recurring_transactions ADD COLUMN end_date TEXT'); } catch (_) { /* already exists */ }
+  try { db.exec('ALTER TABLE recurring_transactions ADD COLUMN created_at TEXT DEFAULT CURRENT_TIMESTAMP'); } catch (_) { /* already exists */ }
 }
 
 // ─── Period helpers ─────────────────────────────────────────────────────────
@@ -501,7 +502,7 @@ export function insertRecurringTransaction(tx: Omit<any, 'id'>) {
     done: tx.done ? 1 : 0,
     active: tx.active !== false ? 1 : 0,
     end_date: tx.end_date || null,
-    created_at: tx.created_at || new Date().toISOString(),
+    created_at: tx.created_at || '21',
   });
   return result.lastInsertRowid as number;
 }

--- a/src/pages/api/kickoff.ts
+++ b/src/pages/api/kickoff.ts
@@ -78,8 +78,24 @@ export const POST: APIRoute = async ({ request }) => {
     const newPeriodDate = new Date(month + ' 1');
     return endDate >= newPeriodDate;
   });
-  const now = new Date().toISOString();
   for (const r of recurring) {
+    // Use recurring created_at day number (1-28) for the transaction's created_time
+    let createdTime: string;
+    if (r.created_at) {
+      const day = parseInt(r.created_at, 10);
+      if (day >= 1 && day <= 28) {
+        const targetDate = new Date(month + ' 1');
+        targetDate.setDate(day);
+        createdTime = targetDate.toISOString();
+      } else {
+        createdTime = new Date().toISOString();
+      }
+    } else {
+      // Default to 21st (salary cycle start)
+      const targetDate = new Date(month + ' 1');
+      targetDate.setDate(21);
+      createdTime = targetDate.toISOString();
+    }
     insertTransaction({
       period_id,
       date: dateStr,
@@ -90,7 +106,7 @@ export const POST: APIRoute = async ({ request }) => {
       type: r.type,
       payment_method: r.payment_method || 'Cash',
       done: r.done ? 1 : 0,
-      created_time: now,
+      created_time: createdTime,
     });
   }
 


### PR DESCRIPTION
## Summary
Add day-of-month field to recurring transactions so each recurring item can specify which day of the month its transaction should appear on.

## Changes
- **DB:** migration + default 21 in `insertRecurringTransaction`
- **UI:** number input (1-28) in add/edit forms, `Tgl` column in table
- **Kickoff:** uses day number to set `created_time` of generated transactions

Closes #99