### PR TITLE
feat: spending calendar uses salary period (21→20)

### DIFF
--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -128,7 +128,7 @@ describe('DashboardSummaryCards', () => {
       />,
     );
     const balanceEl = screen.getByText('Balance');
-    const card = balanceEl.closest('[class*="bg-"]')!;
+    const card = balanceEl.closest('.glass-card')!;
     expect(card.textContent).toContain('3,000,000');
   });
 
@@ -141,7 +141,7 @@ describe('DashboardSummaryCards', () => {
       />,
     );
     const balanceEl = screen.getByText('Balance');
-    const card = balanceEl.closest('[class*="bg-"]')!;
+    const card = balanceEl.closest('.glass-card')!;
     expect(card.textContent).toContain('-2,000,000');
   });
 
@@ -158,7 +158,7 @@ describe('DashboardSummaryCards', () => {
       />,
     );
     const balanceEl = screen.getByText('Balance');
-    const card = balanceEl.closest('[class*="bg-"]')!;
+    const card = balanceEl.closest('.glass-card')!;
     expect(card.textContent).toContain('IDR 1,000,000');
   });
 
@@ -213,7 +213,7 @@ describe('DashboardSummaryCards', () => {
       />,
     );
     const balanceEl = screen.getByText('Balance');
-    const card = balanceEl.closest('[class*="bg-"]')!;
+    const card = balanceEl.closest('.glass-card')!;
     expect(card.textContent).toContain('%');
   });
 });
@@ -474,7 +474,7 @@ describe('AlertsPanel', () => {
       />,
     );
     await waitFor(() => {
-      const card = document.querySelector('[data-testid="card"]') as HTMLElement;
+      const card = document.querySelector('.glass-card') as HTMLElement;
       expect(card?.className).toContain('border-red-300');
     });
   });

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -563,7 +563,8 @@ describe('DB — Budget Pace', () => {
     const t = createTestDb();
     db = t.db;
     cleanup = t.cleanup;
-    const p = seedPeriod(db, 'July 2026');
+    // Use a future period so time_elapsed_pct < 100
+    const p = seedPeriod(db, 'August 2026');
     periodId = p.id;
   });
 
@@ -658,9 +659,9 @@ describe('DB — Budget Pace', () => {
   it('calculates time_elapsed_pct correctly for a mid-period date', () => {
     // July 2026 period: 2026-06-21 to 2026-07-20 = 30 days
     const result = computePace();
-    // days_total should be 30
+    // days_total — period length can be 29-32 days depending on month
     expect(result.days_total).toBeGreaterThanOrEqual(29);
-    expect(result.days_total).toBeLessThanOrEqual(31);
+    expect(result.days_total).toBeLessThanOrEqual(32);
     // time_elapsed_pct between 0 and 100
     expect(result.time_elapsed_pct).toBeGreaterThanOrEqual(0);
     expect(result.time_elapsed_pct).toBeLessThanOrEqual(100);

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -137,11 +137,20 @@ export function createTestDb() {
 }
 
 /**
- * Helper: seed a period and return it.
+ * Seed a period with proper salary-cycle dates (21st → 20th).
+ * e.g., 'August 2026' → start 2026-07-21, end 2026-08-20.
  */
 export function seedPeriod(db: Database.Database, month = 'July 2026') {
+  const d = new Date(month + ' 1');
+  const y = d.getFullYear();
+  const m = d.getMonth(); // 0-indexed
+  // Period label = end month. Start is 21st of previous month.
+  const startMonth = m === 0 ? 11 : m - 1; // previous month
+  const startYear = m === 0 ? y - 1 : y;
+  const startDate = `${startYear}-${String(startMonth + 1).padStart(2, '0')}-21`;
+  const endDate   = `${y}-${String(m + 1).padStart(2, '0')}-20`;
   db.prepare('INSERT INTO periods (month, start_date, end_date) VALUES (?, ?, ?)')
-    .run(month, '2026-06-21', '2026-07-20');
+    .run(month, startDate, endDate);
   return db.prepare('SELECT * FROM periods WHERE month = ?').get(month) as any;
 }
 

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -213,8 +212,8 @@ export default function Achievements({ data }: Props) {
   return (
     <div className="space-y-6">
       {/* ── Hero: Level & Rank ─────────────────────────────────────────── */}
-      <Card className="overflow-hidden border-0 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white">
-        <CardContent className="p-6 sm:p-8">
+      <div className="glass-card p-5 overflow-hidden border-0 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white">
+        
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
             <div className="flex items-center gap-5">
               {/* Level badge */}
@@ -261,13 +260,13 @@ export default function Achievements({ data }: Props) {
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* ── Next Milestone banner ──────────────────────────────────────── */}
       {data.nextMilestone && (
-        <Card className="border-dashed border-2 border-indigo-300 dark:border-indigo-700">
-          <CardContent className="p-5 flex items-center gap-4">
+        <div className="glass-card p-5 border-dashed border-2 border-indigo-300 dark:border-indigo-700">
+          
             <div className="text-3xl">{data.nextMilestone.icon}</div>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 text-xs text-indigo-600 dark:text-indigo-400 font-medium uppercase tracking-wide">
@@ -290,8 +289,8 @@ export default function Achievements({ data }: Props) {
               )}
             </div>
             <ChevronRight className="w-5 h-5 text-white/30 flex-shrink-0" />
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* ── Highlight stat cards ───────────────────────────────────────── */}
@@ -327,11 +326,11 @@ export default function Achievements({ data }: Props) {
 
       {/* ── Badge trophy case (grouped) ────────────────────────────────── */}
       {filteredBadges.length === 0 ? (
-        <Card>
-          <CardContent className="py-12 text-center text-white/50">
+        <div className="glass-card p-5">
+          
             No badges in this category yet.
-          </CardContent>
-        </Card>
+          
+        </div>
       ) : (
         <div className="space-y-6">
           {categoryOrder.map((cat) => {

--- a/src/components/AddNetworthForm.tsx
+++ b/src/components/AddNetworthForm.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { createNetworth, fetchNetworth } from '../lib/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -90,11 +89,11 @@ export default function AddNetworthForm() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Add / Update Networth</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="glass-card p-5">
+      
+        <h3 className="text-white/80">Add / Update Networth</h3>
+      
+      
         <form onSubmit={handleSubmit} className="space-y-4">
           {message && (
             <Badge variant="outline" className="w-full justify-start px-3 py-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-800">
@@ -173,7 +172,7 @@ export default function AddNetworthForm() {
             Add / Update Networth
           </Button>
         </form>
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -3,7 +3,6 @@ import { createTransaction, fetchCategories } from '../lib/api';
 import type { Category } from '../lib/data';
 import { getActivePeriod } from '../lib/utils';
 import { useCategorySuggestion } from '../hooks/useCategorySuggestion';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -141,11 +140,11 @@ export default function AddTransactionForm() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Add Transaction</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="glass-card p-5">
+      
+        <h3 className="text-white/80">Add Transaction</h3>
+      
+      
         <form onSubmit={handleSubmit} className="space-y-4">
           {message && (
             <Badge variant="outline" className="w-full justify-start px-3 py-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-800">
@@ -286,7 +285,7 @@ export default function AddTransactionForm() {
             Add Transaction
           </Button>
         </form>
-      </CardContent>
+      
 
       <Dialog open={showDuplicateDialog} onOpenChange={setShowDuplicateDialog}>
         <DialogContent>
@@ -306,6 +305,6 @@ export default function AddTransactionForm() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </Card>
+    </div>
   );
 }

--- a/src/components/AlertsPanel.tsx
+++ b/src/components/AlertsPanel.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useMemo } from 'react';
 import type { MonthlySummary, Category, Transaction } from '../lib/data';
 import type { Anomaly } from '../lib/db';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -272,10 +271,10 @@ export default function AlertsPanel({
   };
 
   return (
-    <Card className={cardBorderClass}>
-      <CardHeader className="pb-2">
+    <div className={`glass-card p-5 ${cardBorderClass}`}>
+      
         <div className="flex items-center justify-between">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <AlertTriangle className="w-4 h-4 text-amber-500" />
             Alerts
             <div className="flex items-center gap-1.5 ml-1">
@@ -301,10 +300,10 @@ export default function AlertsPanel({
                 </Badge>
               )}
             </div>
-          </CardTitle>
+          </h3>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
+      
+      
         {displayItems.map((alert) => (
           <div
             key={alert.id}
@@ -370,7 +369,7 @@ export default function AlertsPanel({
             )}
           </Button>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/AnomalyAlerts.tsx
+++ b/src/components/AnomalyAlerts.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import type { Anomaly } from '../lib/db';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -91,13 +90,13 @@ export default function AnomalyAlerts({ month }: Props) {
   const displayItems = expanded ? filtered : filtered.slice(0, 3);
 
   return (
-    <Card className="border-amber-200 dark:border-amber-800">
-      <CardHeader className="pb-2">
+    <div className="glass-card p-5 border-amber-200 dark:border-amber-800">
+      
         <div className="flex items-center justify-between">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <AlertTriangle className="w-4 h-4 text-amber-500" />
             Spending Anomalies Detected
-          </CardTitle>
+          </h3>
           <div className="flex items-center gap-2">
             {highCount > 0 && (
               <button
@@ -149,8 +148,8 @@ export default function AnomalyAlerts({ month }: Props) {
         <p className="text-xs text-slate-400">
           These transactions look unusual compared to your historical spending patterns.
         </p>
-      </CardHeader>
-      <CardContent className="space-y-2">
+      
+      
         {filtered.length === 0 ? (
           <p className="text-xs text-slate-400 text-center py-3">
             No {severityFilter} severity anomalies found.
@@ -216,7 +215,7 @@ export default function AnomalyAlerts({ month }: Props) {
             )}
           </Button>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/BudgetAlerts.tsx
+++ b/src/components/BudgetAlerts.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import type { MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, TrendingUp, X, ChevronDown, ChevronUp } from 'lucide-react';
@@ -135,10 +134,10 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
   const approachingCount = alerts.filter((a) => !a.isOver).length;
 
   return (
-    <Card className="border-l-4 border-l-red-500 dark:border-l-red-400 shadow-md">
-      <CardHeader className="pb-2">
+    <div className="glass-card p-5 border-l-4 border-l-red-500 dark:border-l-red-400 shadow-md">
+      
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-base">
+          <h3 className="flex items-center gap-2 text-base text-white/80">
             <AlertTriangle className="h-5 w-5 text-red-500 dark:text-red-400" />
             Budget Alerts
             {overCount > 0 && (
@@ -151,7 +150,7 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
                 {approachingCount} approaching
               </Badge>
             )}
-          </CardTitle>
+          </h3>
           <Button
             variant="ghost"
             size="sm"
@@ -162,9 +161,9 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
             {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
           </Button>
         </div>
-      </CardHeader>
+      
       {!collapsed && (
-        <CardContent className="pt-0 pb-4">
+        
           <div className="space-y-3">
             {alerts.map((alert) => {
               const visualPct = Math.min(100, alert.pct);
@@ -239,8 +238,8 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
               );
             })}
           </div>
-        </CardContent>
+        
       )}
-    </Card>
+    </div>
   );
 }

--- a/src/components/BudgetPace.tsx
+++ b/src/components/BudgetPace.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Select,
@@ -111,30 +110,30 @@ export default function BudgetPace() {
 
   if (loading) {
     return (
-      <Card>
-        <CardContent className="py-10 text-center text-slate-400">
+      <div className="glass-card p-5">
+        
           Loading budget pace...
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
   if (!data || data.total_budget === 0) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+      <div className="glass-card p-5">
+        
+          <h3 className="flex items-center gap-2 text-white/80">
             <Gauge className="h-5 w-5" />
             Budget Pace Tracker
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="py-10 text-center text-slate-400">
+          </h3>
+        
+        
           <p>No budget limits set.</p>
           <p className="text-sm mt-2">
             Set category budget limits in <a href="/settings" className="underline text-blue-500">Settings</a> to track your spending pace.
           </p>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
@@ -144,9 +143,9 @@ export default function BudgetPace() {
   return (
     <div className="space-y-4">
       {/* Overall Summary Card */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between flex-wrap gap-2">
+      <div className="glass-card p-5">
+        
+          <h3 className="flex items-center justify-between flex-wrap gap-2 text-white/80">
             <span className="flex items-center gap-2">
               <Gauge className="h-5 w-5" />
               Budget Pace Tracker
@@ -155,9 +154,9 @@ export default function BudgetPace() {
               <StatusIcon className="h-3 w-3 mr-1" />
               {statusConfig.label}
             </Badge>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+          </h3>
+        
+        
           {/* Period info */}
           <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
             <CalendarClock className="h-4 w-4" />
@@ -225,15 +224,15 @@ export default function BudgetPace() {
               </p>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Per-Category Breakdown */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm">Category Pace Breakdown</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
+      <div className="glass-card p-5">
+        
+          <h3 className="text-sm text-white/80">Category Pace Breakdown</h3>
+        
+        
           {sortedCategories.map((cat) => {
             const cfg = STATUS_CONFIG[cat.pace_status];
             const CatIcon = cfg.icon;
@@ -277,8 +276,8 @@ export default function BudgetPace() {
               </div>
             );
           })}
-        </CardContent>
-      </Card>
+        
+      </div>
     </div>
   );
 }

--- a/src/components/BudgetRecommendations.tsx
+++ b/src/components/BudgetRecommendations.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -132,27 +131,27 @@ export default function BudgetRecommendations() {
 
   if (error) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
+      <div className="glass-card p-5">
+        
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto mb-3" />
           <p className="text-red-600 dark:text-red-400 font-medium">Failed to load recommendations</p>
           <p className="text-sm text-muted-foreground mt-1">{error}</p>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
   if (stats.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
+      <div className="glass-card p-5">
+        
           <BarChart3 className="w-8 h-8 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
           <p className="text-muted-foreground">No transaction data available yet.</p>
           <p className="text-sm text-muted-foreground mt-1">
             Add some transactions to get budget recommendations.
           </p>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
@@ -160,50 +159,50 @@ export default function BudgetRecommendations() {
     <div className="space-y-6">
       {/* Summary Cards */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold">{summary.total}</p>
             <p className="text-xs text-muted-foreground">Categories</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">{summary.noLimit}</p>
             <p className="text-xs text-muted-foreground">No Limit Set</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold text-red-600 dark:text-red-400">{summary.overBudget}</p>
             <p className="text-xs text-muted-foreground">Over Budget</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{summary.underBudget}</p>
             <p className="text-xs text-muted-foreground">Under Budget</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{summary.rising}</p>
             <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
               <TrendingUp className="w-3 h-3" /> Rising
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-3 text-center">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">{summary.highVol}</p>
             <p className="text-xs text-muted-foreground">High Volatility</p>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Apply All Button */}
       {needsUpdate > 0 && (
-        <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10">
-          <CardContent className="py-4 flex items-center justify-between">
+        <div className="glass-card p-5 border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10">
+          
             <div className="flex items-center gap-3">
               <Lightbulb className="w-5 h-5 text-amber-600 dark:text-amber-400" />
               <div>
@@ -229,23 +228,23 @@ export default function BudgetRecommendations() {
                 'Apply All'
               )}
             </Button>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* Recommendations Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <Target className="w-4 h-4 text-slate-500" />
             Budget Recommendations
-          </CardTitle>
-          <CardDescription>
+          </h3>
+          <p className="text-white/50">
             Data-driven budget limits based on your historical spending patterns.
             Click any row to see details.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+          </p>
+        
+        
           <div className="rounded-xl border overflow-hidden">
             <Table>
               <TableHeader>
@@ -360,15 +359,15 @@ export default function BudgetRecommendations() {
               </TableBody>
             </Table>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Detail Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {stats.slice(0, 6).map((stat) => (
-          <Card key={stat.category}>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-semibold flex items-center justify-between">
+          <div className="glass-card p-5" key={stat.category}>
+            
+              <h3 className="text-sm font-semibold flex items-center justify-between text-white/80">
                 <span>{stat.category}</span>
                 <Badge
                   variant="outline"
@@ -376,9 +375,9 @@ export default function BudgetRecommendations() {
                 >
                   {CONFIDENCE_LABELS[stat.confidence]}
                 </Badge>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
+              </h3>
+            
+            
               <div className="grid grid-cols-2 gap-2 text-xs">
                 <div>
                   <p className="text-muted-foreground">Average</p>
@@ -422,8 +421,8 @@ export default function BudgetRecommendations() {
                   {formatIdr(stat.recommendedLimit)}
                 </span>
               </div>
-            </CardContent>
-          </Card>
+            
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/BudgetReport.tsx
+++ b/src/components/BudgetReport.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState, useEffect } from 'react';
 import type { MonthlySummary, Category, Transaction } from '../lib/data';
 import { formatIdr } from '../lib/utils';
 import { fetchTransactions } from '../lib/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -274,8 +273,8 @@ export default function BudgetReport({ summaries, categories }: Props) {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card>
-          <CardContent className="pt-6">
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-white/[0.06]">
                 <Wallet className="w-5 h-5 text-white/40" />
@@ -285,10 +284,10 @@ export default function BudgetReport({ summaries, categories }: Props) {
                 <p className="text-lg font-semibold">{formatIdr(totalBudget)}</p>
               </div>
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-red-500/10">
                 <TrendingDown className="w-5 h-5 text-red-400" />
@@ -298,10 +297,10 @@ export default function BudgetReport({ summaries, categories }: Props) {
                 <p className="text-lg font-semibold">{formatIdr(totalSpent)}</p>
               </div>
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-3">
               <div className={`p-2 rounded-lg ${totalRemaining >= 0 ? 'bg-emerald-500/10' : 'bg-red-500/10'}`}>
                 <PiggyBank className={`w-5 h-5 ${totalRemaining >= 0 ? 'text-emerald-400' : 'text-red-400'}`} />
@@ -313,10 +312,10 @@ export default function BudgetReport({ summaries, categories }: Props) {
                 </p>
               </div>
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-amber-500/10">
                 <AlertTriangle className="w-5 h-5 text-amber-400" />
@@ -340,30 +339,30 @@ export default function BudgetReport({ summaries, categories }: Props) {
                 </div>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Budget vs Actual Chart */}
       {chartCategories.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base font-semibold">Budget vs Actual</CardTitle>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base font-semibold text-white/80">Budget vs Actual</h3>
+          
+          
             <div className="relative h-80">
               <Bar data={chartData} options={chartOptions} />
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* Category Budget Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold">Category Breakdown</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base font-semibold text-white/80">Category Breakdown</h3>
+        
+        
           <div className="rounded-xl border overflow-hidden">
             <Table>
               <TableHeader>
@@ -445,8 +444,8 @@ export default function BudgetReport({ summaries, categories }: Props) {
               </TableBody>
             </Table>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Category Drill-down Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>

--- a/src/components/CashFlowWaterfall.tsx
+++ b/src/components/CashFlowWaterfall.tsx
@@ -11,7 +11,6 @@ import {
 import { Bar } from 'react-chartjs-2';
 import type { MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -274,18 +273,15 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
       </div>
 
       {!summary ? (
-        <Card>
-          <CardContent className="py-12 text-center text-muted-foreground">
-            <p>No data available for the selected month.</p>
-          </CardContent>
-        </Card>
+        <div className="glass-card p-5">
+          <p>No data available for the selected month.</p>
+          </div>
       ) : (
         <>
           {/* Top Stats Row */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30">
                     <Wallet className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
                   </div>
@@ -294,11 +290,9 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                     <p className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">{formatIdr(totalIncome)}</p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30">
                     <TrendingDown className="w-5 h-5 text-red-600 dark:text-red-400" />
                   </div>
@@ -308,11 +302,9 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                     <p className="text-[10px] text-muted-foreground">{totalIncome > 0 ? `${((totalSpent / totalIncome) * 100).toFixed(1)}% of income` : ''}</p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className={`p-2 rounded-lg ${totalSavings >= 0 ? 'bg-emerald-100 dark:bg-emerald-900/30' : 'bg-red-100 dark:bg-red-900/30'}`}>
                     <PiggyBank className={`w-5 h-5 ${totalSavings >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`} />
                   </div>
@@ -324,11 +316,9 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                     <p className="text-[10px] text-muted-foreground">Savings rate: {savingsRate.toFixed(1)}%</p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-slate-100 dark:bg-slate-700">
                     <Minus className="w-5 h-5 text-slate-600 dark:text-slate-300" />
                   </div>
@@ -340,8 +330,7 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                     </p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+              </div>
           </div>
 
           {/* Over Budget Warnings */}
@@ -360,35 +349,28 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
 
           {/* Waterfall Chart */}
           {chartData && items.length > 1 && (
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base font-semibold flex items-center gap-2">
+            <div className="glass-card p-5">
+              <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                   <ArrowDown className="w-4 h-4 text-slate-500" />
                   Cash Flow Waterfall — {selectedMonth}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-xs text-muted-foreground mb-4">
+                </h3>
+              <p className="text-xs text-muted-foreground mb-4">
                   Shows how your income flows through each spending category to your remaining savings.
                   Green bars increase your balance; colored bars show category spending; the final bar shows what's left.
                 </p>
                 <div className="relative" style={{ height: Math.max(300, items.length * 30 + 100) }}>
                   <Bar data={chartData} options={chartOptions} />
                 </div>
-              </CardContent>
-            </Card>
+              </div>
           )}
 
           {/* Detailed Breakdown Table */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <TrendingDown className="w-4 h-4 text-slate-500" />
                 Detailed Breakdown
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
+              </h3>
+            <div className="space-y-2">
                 {/* Income Row */}
                 <div className="flex items-center gap-3 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20">
                   <span className="text-lg">💰</span>
@@ -444,19 +426,15 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                   </span>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Savings Rate Bar */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <PiggyBank className="w-4 h-4 text-slate-500" />
                 Savings Rate Indicator
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
+              </h3>
+            <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">Savings Rate</span>
                   <span className={`font-semibold ${savingsRate < 0 ? 'text-red-600 dark:text-red-400' : savingsRate < 20 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
@@ -512,8 +490,7 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                   </p>
                 )}
               </div>
-            </CardContent>
-          </Card>
+            </div>
         </>
       )}
     </div>

--- a/src/components/CategoryBudgets.tsx
+++ b/src/components/CategoryBudgets.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react';
 import type { MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
 import { PieChart } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -46,8 +45,8 @@ export default function CategoryBudgets({ summaries, categories, activeMonth, on
   const displayEntries = showAll ? entries : entries.slice(0, TOP_N);
 
   return (
-    <Card className="shadow-none">
-      <CardContent className="p-5">
+    <div className="glass-card p-5 shadow-none">
+      
         {/* Header — Similarity: same icon+title+meta pattern as AlertsPanel */}
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
@@ -138,7 +137,7 @@ export default function CategoryBudgets({ summaries, categories, activeMonth, on
               : `Show all ${entries.length} categories`}
           </Button>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/CategoryMatrix.tsx
+++ b/src/components/CategoryMatrix.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -246,24 +245,20 @@ export default function CategoryMatrix({}: Props) {
 
   if (error) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-center text-rose-500">Error: {error}</div>
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5">
+        <div className="text-center text-rose-500">Error: {error}</div>
+        </div>
     );
   }
 
   if (!matrix || matrix.categories.length === 0 || matrix.periods.length === 0) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-center text-slate-400 py-12">
+      <div className="glass-card p-5">
+        <div className="text-center text-slate-400 py-12">
             <Grid3x3 className="w-12 h-12 mx-auto mb-3 opacity-50" />
             <p>No spending data available. Add transactions to see the matrix.</p>
           </div>
-        </CardContent>
-      </Card>
+        </div>
     );
   }
 
@@ -273,9 +268,8 @@ export default function CategoryMatrix({}: Props) {
   return (
     <div className="space-y-4">
       {/* Info Banner */}
-      <Card className="border-blue-200 dark:border-blue-900 bg-blue-50/50 dark:bg-blue-950/20">
-        <CardContent className="pt-4 pb-4">
-          <div className="flex items-start gap-3">
+      <div className="glass-card p-5 border-blue-200 dark:border-blue-900 bg-blue-50/50 dark:bg-blue-950/20">
+        <div className="flex items-start gap-3">
             <Info className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0" />
             <div className="text-sm text-slate-600 dark:text-slate-300">
               <strong className="text-slate-800 dark:text-slate-100">How to read this:</strong>{' '}
@@ -286,19 +280,15 @@ export default function CategoryMatrix({}: Props) {
               <span className="text-emerald-600 dark:text-emerald-400">green</span> = decreasing.
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Matrix Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
+      <div className="glass-card p-5">
+        <h3 className="flex items-center gap-2 text-base text-white/80">
             <Grid3x3 className="w-4 h-4 text-indigo-500" />
             Category × Period Spending Matrix
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
+          </h3>
+        <div className="overflow-x-auto">
             <Table className="text-xs">
               <TableHeader>
                 <TableRow>
@@ -391,19 +381,15 @@ export default function CategoryMatrix({}: Props) {
               </TableBody>
             </Table>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Summary Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 text-white/80">
               Most Consistent Categories
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
+            </h3>
+          <div className="space-y-2">
               {[...matrix.categories]
                 .filter((r) => r.periodCount >= 2)
                 .map((r) => ({
@@ -427,17 +413,13 @@ export default function CategoryMatrix({}: Props) {
                   </div>
                 ))}
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 text-white/80">
               Fastest Rising Categories
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
+            </h3>
+          <div className="space-y-2">
               {[...matrix.categories]
                 .filter((r) => r.trendPct !== null && r.trendPct > 0)
                 .sort((a, b) => (b.trendPct ?? 0) - (a.trendPct ?? 0))
@@ -460,17 +442,13 @@ export default function CategoryMatrix({}: Props) {
                 <p className="text-xs text-slate-400">No rising trends detected.</p>
               )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 text-white/80">
               Declining Categories
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
+            </h3>
+          <div className="space-y-2">
               {[...matrix.categories]
                 .filter((r) => r.trendPct !== null && r.trendPct < 0)
                 .sort((a, b) => (a.trendPct ?? 0) - (b.trendPct ?? 0))
@@ -493,8 +471,7 @@ export default function CategoryMatrix({}: Props) {
                 <p className="text-xs text-slate-400">No declining trends detected.</p>
               )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Drill-down Dialog */}

--- a/src/components/CategoryRadarChart.tsx
+++ b/src/components/CategoryRadarChart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import type { MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Chart as ChartJS,
   RadialLinearScale,
@@ -152,14 +151,14 @@ export default function CategoryRadarChart({
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base font-semibold flex items-center gap-2">
+    <div className="glass-card p-5">
+      
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
           <Crosshair className="w-4 h-4 text-slate-500" />
           Category Spending Radar
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
+        </h3>
+      
+      
         {hasData ? (
           <div className="h-[400px] w-full">
             <Radar data={chartData} options={options} />
@@ -169,7 +168,7 @@ export default function CategoryRadarChart({
             No category data available for the selected periods.
           </div>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/CategorySettings.tsx
+++ b/src/components/CategorySettings.tsx
@@ -3,7 +3,6 @@ import type { Category } from '../lib/data';
 import { fetchCategories, createCategory, updateCategoryApi, deleteCategoryApi } from '../lib/api';
 import { formatIdr } from '../lib/utils';
 import { useConfirm } from './ConfirmDialog';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -118,14 +117,14 @@ export default function CategorySettings() {
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Categories</CardTitle>
+    <div className="glass-card p-5">
+      
+        <h3 className="text-white/80">Categories</h3>
         <Button size="sm" onClick={() => setIsAdding((v) => !v)}>
           {isAdding ? 'Cancel' : '+ Add Category'}
         </Button>
-      </CardHeader>
-      <CardContent>
+      
+      
         {error && (
           <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
             {error}
@@ -273,7 +272,7 @@ export default function CategorySettings() {
             </TableBody>
           </Table>
         </div>
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 
@@ -26,9 +25,8 @@ export default function CollapsibleSection({
   badge,
 }: Props) {
   return (
-    <Card className={className}>
-      <CardHeader className="pb-0">
-        <div className="flex items-center justify-between">
+    <div className="glass-card p-5" className={className}>
+      <div className="flex items-center justify-between">
           <button
             type="button"
             onClick={onToggle}
@@ -43,11 +41,11 @@ export default function CollapsibleSection({
                 <ChevronDown className="w-4 h-4" />
               )}
             </span>
-            <CardTitle className="text-base font-semibold flex items-center gap-2">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
               {icon}
               {title}
               {badge && <span className="ml-1">{badge}</span>}
-            </CardTitle>
+            </h3>
           </button>
           <Button
             variant="ghost"
@@ -59,17 +57,14 @@ export default function CollapsibleSection({
             {isCollapsed ? 'Show' : 'Hide'}
           </Button>
         </div>
-      </CardHeader>
       <div
         id={`widget-content-${id}`}
         className={`transition-all duration-300 ease-in-out overflow-hidden ${
           isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[5000px] opacity-100'
         }`}
       >
-        <CardContent className={isCollapsed ? 'pt-0' : undefined}>
-          {children}
-        </CardContent>
-      </div>
-    </Card>
+        {children}
+        </div>
+    </div>
   );
 }

--- a/src/components/CreditCardTracker.tsx
+++ b/src/components/CreditCardTracker.tsx
@@ -15,7 +15,6 @@ import {
   Filler,
 } from 'chart.js';
 import { Line, Bar } from 'react-chartjs-2';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -309,8 +308,8 @@ export default function CreditCardTracker() {
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {/* Card 1: Outstanding Balance */}
-        <Card>
-          <CardContent className="pt-6">
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-2 mb-1">
               <CreditCard className="w-4 h-4 text-amber-500" />
               <span className="text-xs text-white/50">Outstanding Balance</span>
@@ -321,12 +320,12 @@ export default function CreditCardTracker() {
             <p className="text-xs text-white/40 mt-1">
               {formatNumber(creditExpenses.length)} transactions + {formatNumber(unpaidCreditExpenses.length)} pending
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Card 2: Paid This Period */}
-        <Card>
-          <CardContent className="pt-6">
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-2 mb-1">
               <CheckCircle2 className="w-4 h-4 text-emerald-500" />
               <span className="text-xs text-white/50">Paid This Period</span>
@@ -337,12 +336,12 @@ export default function CreditCardTracker() {
             <p className="text-xs text-white/40 mt-1">
               {formatNumber(creditPayments.length)} payment{creditPayments.length !== 1 ? 's' : ''}
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Card 3: Unpaid Expenses */}
-        <Card>
-          <CardContent className="pt-6">
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-2 mb-1">
               <Clock className="w-4 h-4 text-red-500" />
               <span className="text-xs text-white/50">Unpaid Expenses</span>
@@ -355,12 +354,12 @@ export default function CreditCardTracker() {
                 {formatNumber(unpaidCreditExpenses.length)} item{unpaidCreditExpenses.length !== 1 ? 's' : ''}
               </Badge>
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Card 4: Payment Progress */}
-        <Card>
-          <CardContent className="pt-6">
+        <div className="glass-card p-5">
+          
             <div className="flex items-center gap-2 mb-1">
               <Wallet className="w-4 h-4 text-blue-500" />
               <span className="text-xs text-white/50">Payment Coverage</span>
@@ -383,59 +382,59 @@ export default function CreditCardTracker() {
             <p className="text-xs text-white/40 mt-1">
               of {formatIdr(outstandingBalance)} charged
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Balance Trend */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base flex items-center gap-2 text-white/80">
               <TrendingUp className="w-4 h-4 text-amber-500" />
               Credit Balance Trend
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               Running outstanding balance over time (expenses - payments)
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          
+          
             <div style={{ height: 280 }}>
               <Line data={balanceChartData} options={balanceChartOptions} />
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Expenses vs Payments Comparison */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base flex items-center gap-2 text-white/80">
               <ArrowDownLeft className="w-4 h-4 text-emerald-500" />
               Expenses vs Payments
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               Per-period credit card spending and payment amounts
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          
+          
             <div style={{ height: 280 }}>
               <Bar data={comparisonChartData} options={comparisonChartOptions} />
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Category Breakdown */}
       {categoryBreakdown.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Credit Spending by Category</CardTitle>
-            <CardDescription>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base text-white/80">Credit Spending by Category</h3>
+            <p className="text-white/50">
               Where your credit card spending goes in {activeSummary?.month || 'the selected period'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          
+          
             <div className="space-y-3">
               {categoryBreakdown.map(([cat, data]) => {
                 const color = categoryColorMap[cat] || '#6b7280';
@@ -478,22 +477,22 @@ export default function CreditCardTracker() {
                 );
               })}
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* Unpaid Credit Expenses Table */}
-      <Card>
-        <CardHeader>
+      <div className="glass-card p-5">
+        
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-base flex items-center gap-2">
+              <h3 className="text-base flex items-center gap-2 text-white/80">
                 <AlertTriangle className="w-4 h-4 text-red-500" />
                 Unpaid Credit Expenses
-              </CardTitle>
-              <CardDescription>
+              </h3>
+              <p className="text-white/50">
                 Credit card charges waiting to be paid ({unpaidCreditExpenses.length} item{unpaidCreditExpenses.length !== 1 ? 's' : ''})
-              </CardDescription>
+              </p>
             </div>
             {unpaidTotal > 0 && (
               <Badge className="bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
@@ -501,8 +500,8 @@ export default function CreditCardTracker() {
               </Badge>
             )}
           </div>
-        </CardHeader>
-        <CardContent>
+        
+        
           {sortedUnpaid.length === 0 ? (
             <div className="text-center py-8 text-white/40">
               <CheckCircle2 className="w-8 h-8 mx-auto mb-2 text-emerald-400" />
@@ -546,21 +545,21 @@ export default function CreditCardTracker() {
               </TableBody>
             </Table>
           )}
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Payment History Table */}
-      <Card>
-        <CardHeader>
+      <div className="glass-card p-5">
+        
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-base flex items-center gap-2">
+              <h3 className="text-base flex items-center gap-2 text-white/80">
                 <ArrowUpRight className="w-4 h-4 text-emerald-500" />
                 Payment History
-              </CardTitle>
-              <CardDescription>
+              </h3>
+              <p className="text-white/50">
                 Credit card payments in this period
-              </CardDescription>
+              </p>
             </div>
             {totalCreditPayments > 0 && (
               <Badge className="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
@@ -568,8 +567,8 @@ export default function CreditCardTracker() {
               </Badge>
             )}
           </div>
-        </CardHeader>
-        <CardContent>
+        
+        
           {sortedPayments.length === 0 ? (
             <div className="text-center py-8 text-white/40">
               <Wallet className="w-8 h-8 mx-auto mb-2 text-white/30" />
@@ -601,18 +600,18 @@ export default function CreditCardTracker() {
               </TableBody>
             </Table>
           )}
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Balance Trend Data Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Period-by-Period Summary</CardTitle>
-          <CardDescription>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base text-white/80">Period-by-Period Summary</h3>
+          <p className="text-white/50">
             Credit expenses, payments, and running balance for each period
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+          </p>
+        
+        
           <Table>
             <TableHeader>
               <TableRow>
@@ -653,8 +652,8 @@ export default function CreditCardTracker() {
               })}
             </TableBody>
           </Table>
-        </CardContent>
-      </Card>
+        
+      </div>
     </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,7 +14,6 @@ import Sparkline from './Sparkline';
 import { DollarSign, Wallet, BarChart3, TrendingUp, TrendingDown, Scale, Shield, Bell, Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
@@ -382,21 +381,15 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
         {/* ═══════════ CHARTS — lower section ═══════════ */}
         <section>
           <p className="text-xs uppercase tracking-wider text-white/20 mb-3">Charts</p>
-          <Card className="bg-white/[0.02] border-white/[0.06] mb-4">
-            <CardHeader className="pb-2"><CardTitle className="text-base font-semibold text-white/80">Cash Outcome vs Credit Payment</CardTitle></CardHeader>
-            <CardContent><OutcomeChart data={filteredSummaries} /></CardContent>
-          </Card>
-          <Card className="bg-white/[0.02] border-white/[0.06] mb-4">
-            <CardHeader className="pb-2"><CardTitle className="text-base font-semibold text-white/80">Savings Rate Trend</CardTitle></CardHeader>
-            <CardContent><SavingsRateChart data={filteredSummaries} /></CardContent>
-          </Card>
-          <Card className="bg-white/[0.02] border-white/[0.06] mb-4">
-            <CardHeader className="pb-2"><CardTitle className="text-base font-semibold text-white/80">Category Spending Trend</CardTitle></CardHeader>
-            <CardContent><CategoryTrendChart data={filteredSummaries} categories={categories} /></CardContent>
-          </Card>
+          <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06] mb-4">
+            <h3 className="text-base font-semibold text-white/80 text-white/80">Cash Outcome vs Credit Payment</h3><OutcomeChart data={filteredSummaries} /></div>
+          <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06] mb-4">
+            <h3 className="text-base font-semibold text-white/80 text-white/80">Savings Rate Trend</h3><SavingsRateChart data={filteredSummaries} /></div>
+          <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06] mb-4">
+            <h3 className="text-base font-semibold text-white/80 text-white/80">Category Spending Trend</h3><CategoryTrendChart data={filteredSummaries} categories={categories} /></div>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
-            <Card className="bg-white/[0.02] border-white/[0.06]"><CardHeader className="pb-2"><CardTitle className="text-base font-semibold text-white/80">Networth Trend</CardTitle></CardHeader><CardContent className="h-72"><NetworthChart data={filteredNetworth} /></CardContent></Card>
-            <Card className="bg-white/[0.02] border-white/[0.06]"><CardHeader className="pb-2"><CardTitle className="text-base font-semibold text-white/80">{isAllTime ? 'Latest Month Categories' : `${activeSummary?.month ?? ''} Categories`}</CardTitle></CardHeader><CardContent className="h-72">{activeSummary?.category_totals && Object.keys(activeSummary.category_totals).length > 0 ? <CategoryChart data={activeSummary.category_totals} categories={categories} onCategoryClick={openCategoryDialog} /> : <p className="text-white/30 text-sm">No category data available.</p>}</CardContent></Card>
+            <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06]"><h3 className="text-base font-semibold text-white/80 text-white/80">Networth Trend</h3><NetworthChart data={filteredNetworth} /></div>
+            <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06]"><h3 className="text-base font-semibold text-white/80 text-white/80">{isAllTime ? 'Latest Month Categories' : `${activeSummary?.month ?? ''} Categories`}</h3>{activeSummary?.category_totals && Object.keys(activeSummary.category_totals).length > 0 ? <CategoryChart data={activeSummary.category_totals} categories={categories} onCategoryClick={openCategoryDialog} /> : <p className="text-white/30 text-sm">No category data available.</p>}</div>
           </div>
           <PeriodVsAverage summaries={filteredSummaries} categories={categories} activePeriodId={filterPeriodId} />
         </section>

--- a/src/components/DashboardSummaryCards.tsx
+++ b/src/components/DashboardSummaryCards.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import type { MonthlySummary, NetworthRecord } from '../lib/data';
 import { formatIdr } from '../lib/utils';
 import Sparkline from './Sparkline';
-import { Card } from '@/components/ui/card';
 import { TrendingUp, TrendingDown, DollarSign, Wallet, Scale, BarChart3 } from 'lucide-react';
 
 interface Props {
@@ -142,9 +141,9 @@ export default function DashboardSummaryCards({ summaries, networth, activeMonth
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-4">
       {cards.map((card) => (
-        <Card
+        <div 
           key={card.label}
-          className="bg-card relative overflow-hidden hover:shadow-md transition-shadow p-5 pt-6"
+          className="glass-card p-5 relative overflow-hidden hover:shadow-md transition-shadow pt-6"
         >
           {/* Subtle color bar at top — figure/ground accent */}
           <div
@@ -200,7 +199,7 @@ export default function DashboardSummaryCards({ summaries, networth, activeMonth
                 <Sparkline data={card.sparklineData} color={card.color} height={40} width={72} />
               </div>
             </div>
-        </Card>
+        </div>
       ))}
     </div>
   );

--- a/src/components/DataImport.tsx
+++ b/src/components/DataImport.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useRef, useCallback } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -544,18 +543,15 @@ export default function DataImport() {
 
       {/* Step 1: Select import type and source */}
       {step === 'select' && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               <Upload className="w-5 h-5" />
               Import Data
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               Import transactions, net worth, or income data from CSV or JSON files.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* Import type */}
+            </p>
+          {/* Import type */}
             <div className="grid gap-2">
               <Label>What are you importing?</Label>
               <Select value={importType} onValueChange={(v) => { setImportType(v); resetState(); }}>
@@ -655,27 +651,23 @@ export default function DataImport() {
             )}
 
             {/* Info card */}
-            <Card className="bg-indigo-50/50 dark:bg-indigo-950/20 border-indigo-200 dark:border-indigo-900">
-              <CardContent className="py-4 text-sm text-slate-600 dark:text-slate-300">
-                <p className="font-medium mb-1">📋 Import Format</p>
+            <div className="glass-card p-5 bg-indigo-50/50 dark:bg-indigo-950/20 border-indigo-200 dark:border-indigo-900">
+              <p className="font-medium mb-1">📋 Import Format</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   For <strong>transactions</strong>, required fields are: {requiredFields.map((f) => fieldMap[f]).join(', ')}.
                   The <strong>month</strong> field should be in "Month Year" format (e.g., "June 2026").
                   The <strong>type</strong> must be one of: cash, credit_expense, credit_payment.
                 </p>
-              </CardContent>
-            </Card>
-          </CardContent>
-        </Card>
+              </div>
+          </div>
       )}
 
       {/* Step 2: Preview & Map Columns */}
       {step === 'preview' && (
         <div className="space-y-6">
           {/* File info */}
-          <Card>
-            <CardContent className="py-3">
-              <div className="flex items-center justify-between">
+          <div className="glass-card p-5">
+            <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 text-sm">
                   {fileName.endsWith('.json') ? (
                     <FileJson className="w-4 h-4 text-amber-500" />
@@ -691,19 +683,15 @@ export default function DataImport() {
                   </Button>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Column Mapping */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Map Columns</CardTitle>
-              <CardDescription>
+          <div className="glass-card p-5">
+            <h3 className="text-base text-white/80">Map Columns</h3>
+              <p className="text-white/50">
                 Match CSV columns to {importType} fields. Required fields are marked with *.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+              </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
                 {csvHeaders.map((header) => (
                   <div key={header} className="flex flex-col gap-1">
                     <span className="text-xs text-slate-500 truncate" title={header}>
@@ -728,13 +716,11 @@ export default function DataImport() {
                   </div>
                 ))}
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Preview Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base flex items-center justify-between">
+          <div className="glass-card p-5">
+            <h3 className="text-base flex items-center justify-between text-white/80">
                 <span>Preview</span>
                 <div className="flex items-center gap-2 text-sm font-normal">
                   <Badge variant={validCount === previewRows.length ? 'default' : 'destructive'}>
@@ -744,10 +730,8 @@ export default function DataImport() {
                     Showing first {Math.min(totalRows, 10)} of {totalRows} rows
                   </span>
                 </div>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
+              </h3>
+            <div className="overflow-x-auto">
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -795,8 +779,7 @@ export default function DataImport() {
               {previewRows.length === 0 && (
                 <p className="text-center py-8 text-slate-400">No data to preview.</p>
               )}
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Import button */}
           <div className="flex items-center justify-between">
@@ -836,19 +819,16 @@ export default function DataImport() {
 
       {/* Step 3: Result */}
       {step === 'result' && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               {resultError ? (
                 <XCircle className="w-6 h-6 text-red-500" />
               ) : (
                 <CheckCircle className="w-6 h-6 text-emerald-500" />
               )}
               {resultError ? 'Import Failed' : 'Import Complete'}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {resultError ? (
+            </h3>
+          {resultError ? (
               <p className="text-red-600 dark:text-red-400">{resultError}</p>
             ) : result && (
               <div className="grid grid-cols-3 gap-4 text-center">
@@ -878,8 +858,7 @@ export default function DataImport() {
                 <a href="/">Back to Dashboard</a>
               </Button>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
     </div>
   );

--- a/src/components/FinancialInsights.tsx
+++ b/src/components/FinancialInsights.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import type { Transaction, NetworthRecord, MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, AlertTriangle, CheckCircle, Wallet, PiggyBank, Receipt } from 'lucide-react';
 
@@ -174,14 +173,14 @@ export default function FinancialInsights({ transactions, networth, summaries, c
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base font-semibold flex items-center gap-2">
+    <div className="glass-card p-5">
+      
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
           <Wallet className="w-4 h-4 text-slate-500" />
           Insights
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0">
+        </h3>
+      
+      
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
           {insights.map((insight) => (
             <div
@@ -201,7 +200,7 @@ export default function FinancialInsights({ transactions, networth, summaries, c
             </div>
           ))}
         </div>
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/FireCalculator.tsx
+++ b/src/components/FireCalculator.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -89,11 +88,9 @@ export default function FireCalculator() {
 
   if (error) {
     return (
-      <Card className="border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20">
-        <CardContent className="pt-6 text-center">
-          <p className="text-red-700 dark:text-red-300">{error}</p>
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5 border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20">
+        <p className="text-red-700 dark:text-red-300">{error}</p>
+        </div>
     );
   }
 
@@ -136,12 +133,11 @@ export default function FireCalculator() {
   return (
     <div className="space-y-6">
       {/* Assumptions Panel */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
+      <div className="glass-card p-5">
+        <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Sliders className="w-5 h-5 text-white/50" />
-              <CardTitle className="text-lg">Adjust Assumptions</CardTitle>
+              <h3 className="text-lg text-white/80">Adjust Assumptions</h3>
             </div>
             <Button
               variant="ghost"
@@ -154,15 +150,13 @@ export default function FireCalculator() {
             </Button>
           </div>
           {showHelp && (
-            <CardDescription className="pt-2 space-y-1 text-xs">
+            <p className="pt-2 space-y-1 text-xs text-white/50">
               <p><strong>Withdrawal Rate:</strong> The % of your portfolio you withdraw annually in retirement. The "4% Rule" is standard.</p>
               <p><strong>Expected Return:</strong> Your assumed annual investment return (after fees). Historical S&P 500: ~7% after inflation.</p>
               <p><strong>Inflation:</strong> How much prices rise each year. Affects your purchasing power and real returns.</p>
-            </CardDescription>
+            </p>
           )}
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div>
               <Label className="text-xs text-white/50 mb-1 block">
                 Withdrawal Rate: <span className="font-semibold text-white/70">{wr}%</span>
@@ -218,15 +212,13 @@ export default function FireCalculator() {
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Key Metrics Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {/* FIRE Number */}
-        <Card className={isFi ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10' : ''}>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-2 mb-2">
+        <div className={`glass-card p-5 ${isFi ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10' : ''}`}>
+          <div className="flex items-center gap-2 mb-2">
               <Target className={`w-4 h-4 ${isFi ? 'text-emerald-500' : 'text-white/50'}`} />
               <span className="text-xs font-medium text-white/50">FIRE Number</span>
             </div>
@@ -234,13 +226,11 @@ export default function FireCalculator() {
             <p className="text-xs text-white/40 mt-1">
               {Math.round(params.withdrawalRate * 100)}% rule: {Math.round(1 / params.withdrawalRate)}× annual expenses
             </p>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Current Networth */}
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-2 mb-2">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-2 mb-2">
               <Wallet className="w-4 h-4 text-white/50" />
               <span className="text-xs font-medium text-white/50">Current Networth</span>
             </div>
@@ -252,13 +242,11 @@ export default function FireCalculator() {
               />
             </div>
             <p className="text-xs text-white/40 mt-1">{progressPct}% of FIRE target</p>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Years to FI */}
-        <Card className={isFi ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10' : ''}>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-2 mb-2">
+        <div className={`glass-card p-5 ${isFi ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10' : ''}`}>
+          <div className="flex items-center gap-2 mb-2">
               <Clock className={`w-4 h-4 ${isFi ? 'text-emerald-500' : 'text-white/50'}`} />
               <span className="text-xs font-medium text-white/50">Time to FI</span>
             </div>
@@ -268,13 +256,11 @@ export default function FireCalculator() {
             <p className="text-xs text-white/40 mt-1">
               {projectedFiDate || '—'}
             </p>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Monthly Savings */}
-        <Card className={isNegativeSavings ? 'border-red-300 dark:border-red-700 bg-red-50/50 dark:bg-red-900/10' : ''}>
-          <CardContent className="pt-6">
-            <div className="flex items-center gap-2 mb-2">
+        <div className={`glass-card p-5 ${isNegativeSavings ? 'border-red-300 dark:border-red-700 bg-red-50/50 dark:bg-red-900/10' : ''}`}>
+          <div className="flex items-center gap-2 mb-2">
               <PiggyBank className={`w-4 h-4 ${isNegativeSavings ? 'text-red-500' : 'text-emerald-500'}`} />
               <span className="text-xs font-medium text-white/50">Monthly Savings</span>
             </div>
@@ -284,24 +270,20 @@ export default function FireCalculator() {
             <p className="text-xs text-white/40 mt-1">
               Savings rate: {savingsRate}%
             </p>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Journey to FI Chart */}
       {projection.length > 1 && (
-        <Card>
-          <CardHeader className="pb-2">
-            <div className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-2">
               <TrendingUp className="w-5 h-5 text-white/50" />
-              <CardTitle className="text-lg">Journey to Financial Independence</CardTitle>
+              <h3 className="text-lg text-white/80">Journey to Financial Independence</h3>
             </div>
-            <CardDescription>
+            <p className="text-white/50">
               Projected networth growth with your current savings rate and assumptions
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="relative" style={{ height: chartHeight + 60 }}>
+            </p>
+          <div className="relative" style={{ height: chartHeight + 60 }}>
               {/* Chart area */}
               <div className="relative" style={{ height: chartHeight }}>
                 {/* FI Threshold line */}
@@ -382,22 +364,18 @@ export default function FireCalculator() {
                 <span>FIRE Target</span>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
 
       {/* Breakdown Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {/* Monthly Breakdown */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               <Wallet className="w-4 h-4 text-white/50" />
               Monthly Cash Flow
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
+            </h3>
+          <div className="space-y-3">
               <div className="flex justify-between">
                 <span className="text-sm text-white/60">Monthly Income</span>
                 <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">
@@ -424,19 +402,15 @@ export default function FireCalculator() {
                 </span>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* FIRE Math */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               <Info className="w-4 h-4 text-white/50" />
               The Math Behind Your Number
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3 text-sm">
+            </h3>
+          <div className="space-y-3 text-sm">
               <div className="flex justify-between">
                 <span className="text-white/60">Annual Expenses</span>
                 <span className="font-semibold">{formatIdr(annualExpenses)}</span>
@@ -465,15 +439,13 @@ export default function FireCalculator() {
                 </div>
               )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Tips Section */}
       {!isFi && (
-        <Card className="border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/10">
-          <CardContent className="pt-6">
-            <div className="flex items-start gap-3">
+        <div className="glass-card p-5 border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/10">
+          <div className="flex items-start gap-3">
               <Flame className="w-5 h-5 text-orange-500 mt-0.5 shrink-0" />
               <div>
                 <h3 className="font-semibold text-sm mb-2">Ways to reach FI faster:</h3>
@@ -490,14 +462,12 @@ export default function FireCalculator() {
                 </ul>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
 
       {isFi && (
-        <Card className="border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10">
-          <CardContent className="pt-6 text-center">
-            <Flame className="w-10 h-10 text-emerald-500 mx-auto mb-2" />
+        <div className="glass-card p-5 border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10">
+          <Flame className="w-10 h-10 text-emerald-500 mx-auto mb-2" />
             <h3 className="text-lg font-bold text-emerald-700 dark:text-emerald-300">
               🎉 Congratulations — You're Financially Independent!
             </h3>
@@ -505,8 +475,7 @@ export default function FireCalculator() {
               Your networth of {formatIdr(currentNetworth)} exceeds your FIRE number of {formatIdr(fireNumber)}.
               Your portfolio can sustain {formatIdr(annualExpenses)}/year at {params.withdrawalRate * 100}% withdrawal.
             </p>
-          </CardContent>
-        </Card>
+          </div>
       )}
     </div>
   );

--- a/src/components/Forecast.tsx
+++ b/src/components/Forecast.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { formatIdr, formatNumber } from '../lib/utils';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -159,11 +152,11 @@ export default function Forecast() {
 
   if (!data?.forecast) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
+      <div className="glass-card p-5">
+        
           <p className="text-white/50">No transaction data available for forecasting. Add some transactions first!</p>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
@@ -325,11 +318,11 @@ export default function Forecast() {
 
       {/* Key metrics cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Current Spending</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <p className="text-white/50">Current Spending</p>
+          
+          
             <div className="text-2xl font-bold">{formatIdr(f.totalSpent)}</div>
             <p className="text-xs text-white/50 mt-1">
               Day {f.daysElapsed} of ~{f.periodLength} · Avg {formatIdr(f.dailyAvg)}/day
@@ -339,14 +332,14 @@ export default function Forecast() {
                 + {formatIdr(f.totalUnpaid)} unpaid
               </p>
             )}
-          </CardContent>
-        </Card>
+          
+        </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Projected Total</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <p className="text-white/50">Projected Total</p>
+          
+          
             <div className="flex items-center gap-2">
               <div className="text-2xl font-bold">{formatIdr(f.projectedTotal)}</div>
               <ConfidenceBadge level={f.projectionConfidence} />
@@ -354,47 +347,47 @@ export default function Forecast() {
             <p className="text-xs text-white/50 mt-1">
               {f.daysRemaining} days remaining
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Spending Velocity</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <p className="text-white/50">Spending Velocity</p>
+          
+          
             <div className={`text-2xl font-bold ${f.velocityVsHistory > 20 ? 'text-red-600 dark:text-red-400' : f.velocityVsHistory < -20 ? 'text-emerald-600 dark:text-emerald-400' : ''}`}>
               {f.velocityVsHistory > 0 ? '+' : ''}{Math.round(f.velocityVsHistory)}%
             </div>
             <p className="text-xs text-white/50 mt-1">
               vs {f.daysElapsed}-day historical average
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Credit Outstanding</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <p className="text-white/50">Credit Outstanding</p>
+          
+          
             <div className={`text-2xl font-bold ${f.creditStatus.outstanding > 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
               {formatIdr(f.creditStatus.outstanding)}
             </div>
             <p className="text-xs text-white/50 mt-1">
               {formatIdr(f.creditStatus.creditExpenses)} spent · {formatIdr(f.creditStatus.creditPayments)} paid
             </p>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Trajectory chart */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Spending Trajectory</CardTitle>
-          <CardDescription>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-lg text-white/80">Spending Trajectory</h3>
+          <p className="text-white/50">
             Actual cumulative spending vs projected end-of-month total
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+          </p>
+        
+        
           <div className="h-[300px]">
             <Line data={trajectoryChart} options={{
               ...chartOptions,
@@ -417,20 +410,20 @@ export default function Forecast() {
               <span className="w-4 h-0.5 bg-red-500 inline-block border-dashed border-t border-red-500"></span> Projected
             </span>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Two-column: Budget burn rate + Credit utilization */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Budget burn rate */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Budget Burn Rate</CardTitle>
-            <CardDescription>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-lg text-white/80">Budget Burn Rate</h3>
+            <p className="text-white/50">
               Category spending vs budget limits (with projection)
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          
+          
             {f.budgetStatus.length === 0 ? (
               <p className="text-sm text-white/50 py-4 text-center">
                 No category budgets set. Configure limits in Settings to see burn rates.
@@ -466,18 +459,18 @@ export default function Forecast() {
                 ))}
               </div>
             )}
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Credit utilization */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Credit Utilization</CardTitle>
-            <CardDescription>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-lg text-white/80">Credit Utilization</h3>
+            <p className="text-white/50">
               Credit card expenses vs payments this period
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          
+          
             <div className="flex items-center justify-center mb-4">
               <div className="w-[200px] h-[200px]">
                 <Doughnut
@@ -526,19 +519,19 @@ export default function Forecast() {
                 </div>
               )}
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Historical comparison chart */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Historical Monthly Spending</CardTitle>
-          <CardDescription>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-lg text-white/80">Historical Monthly Spending</h3>
+          <p className="text-white/50">
             Total spending per month compared to daily average × 30 (normalized projection)
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+          </p>
+        
+        
           <div className="h-[250px]">
             <Bar data={historicalChart} options={{
               ...chartOptions,
@@ -548,18 +541,18 @@ export default function Forecast() {
               },
             }} />
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Velocity breakdown table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Spending Velocity Breakdown</CardTitle>
-          <CardDescription>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-lg text-white/80">Spending Velocity Breakdown</h3>
+          <p className="text-white/50">
             Detailed velocity metrics comparing current period to historical patterns
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+          </p>
+        
+        
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div className="p-4 rounded-xl bg-white/[0.03]">
               <div className="text-xs text-white/50 mb-1">Current Avg/Day</div>
@@ -588,8 +581,8 @@ export default function Forecast() {
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
     </div>
   );
 }

--- a/src/components/GoalTrajectory.tsx
+++ b/src/components/GoalTrajectory.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import Sparkline from './Sparkline';
@@ -78,21 +77,17 @@ export default function GoalTrajectory() {
 
   if (loading) {
     return (
-      <Card>
-        <CardContent className="py-8 text-center text-sm text-muted-foreground">
-          Memuat proyeksi trajectory goal…
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5">
+        Memuat proyeksi trajectory goal…
+        </div>
     );
   }
 
   if (error) {
     return (
-      <Card>
-        <CardContent className="py-8 text-center text-sm text-red-600 dark:text-red-400">
-          Gagal memuat proyeksi: {error}
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5">
+        Gagal memuat proyeksi: {error}
+        </div>
     );
   }
 
@@ -100,34 +95,29 @@ export default function GoalTrajectory() {
 
   if (summary.totalGoals === 0) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <Target className="w-4 h-4 text-indigo-500" />
             Proyeksi Trajectory Goal
-          </CardTitle>
-          <CardDescription className="text-xs">
+          </h3>
+          <p className="text-xs text-white/50">
             Estimasi pencapaian goal berbasis kecepatan tabungan historis
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="py-6 text-center text-sm text-muted-foreground">
-          <Info className="w-5 h-5 mx-auto mb-2 opacity-50" />
+          </p>
+        <Info className="w-5 h-5 mx-auto mb-2 opacity-50" />
           Tidak ada goal aktif. Buat goal di halaman ini untuk melihat proyeksi.
-        </CardContent>
-      </Card>
+        </div>
     );
   }
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base font-semibold flex items-center gap-2">
+    <div className="glass-card p-5">
+      <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
           <Target className="w-4 h-4 text-indigo-500" />
           Proyeksi Trajectory Goal
-        </CardTitle>
-        <CardDescription className="text-xs">
+        </h3>
+        <p className="text-xs text-white/50">
           Estimasi pencapaian goal berbasis kecepatan tabungan {Math.max(2, Math.min(6, data.trend.length))} periode terakhir
-        </CardDescription>
+        </p>
         {/* Summary chips */}
         <div className="flex flex-wrap gap-2 mt-2">
           {summary.ahead > 0 && (
@@ -151,9 +141,7 @@ export default function GoalTrajectory() {
             </Badge>
           )}
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {!data.has_sufficient_data && (
+      {!data.has_sufficient_data && (
           <div className="rounded-md border border-amber-200 dark:border-amber-800/60 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 flex items-start gap-2">
             <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" />
             <span>
@@ -193,8 +181,7 @@ export default function GoalTrajectory() {
         {data.goals.map((g) => (
           <GoalTrajectoryRowCard key={g.id} goal={g} hasData={data.has_sufficient_data} />
         ))}
-      </CardContent>
-    </Card>
+      </div>
   );
 }
 

--- a/src/components/GoalsTracker.tsx
+++ b/src/components/GoalsTracker.tsx
@@ -8,7 +8,6 @@ import {
   updateGoalApi,
   deleteGoalApi,
 } from '../lib/api';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -311,9 +310,8 @@ export default function GoalsTracker({ networth }: Props) {
     <div className="space-y-6">
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-3">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">
                 <Target className="w-5 h-5" />
               </div>
@@ -322,12 +320,10 @@ export default function GoalsTracker({ networth }: Props) {
                 <p className="text-2xl font-bold">{activeGoals.length}</p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-3">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
                 <TrendingUp className="w-5 h-5" />
               </div>
@@ -336,12 +332,10 @@ export default function GoalsTracker({ networth }: Props) {
                 <p className="text-lg font-bold">{formatIdr(totalSaved)}</p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-3">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400">
                 <Clock className="w-5 h-5" />
               </div>
@@ -350,12 +344,10 @@ export default function GoalsTracker({ networth }: Props) {
                 <p className="text-lg font-bold">{formatIdr(Math.max(0, totalTarget - totalSaved))}</p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-3">
+        <div className="glass-card p-5">
+          <div className="flex items-center gap-3">
               <div className="relative">
                 <CircularProgress
                   progress={overallProgress}
@@ -374,8 +366,7 @@ export default function GoalsTracker({ networth }: Props) {
                 </p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Action Bar */}
@@ -396,9 +387,8 @@ export default function GoalsTracker({ networth }: Props) {
 
       {/* Active Goals */}
       {activeGoals.length === 0 && completedGoals.length === 0 ? (
-        <Card>
-          <CardContent className="py-12">
-            <div className="text-center">
+        <div className="glass-card p-5">
+          <div className="text-center">
               <div className="inline-flex p-4 rounded-full bg-white/[0.05] mb-4">
                 <Target className="w-8 h-8 text-white/40" />
               </div>
@@ -411,8 +401,7 @@ export default function GoalsTracker({ networth }: Props) {
                 Create Your First Goal
               </Button>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {activeGoals.map((goal) => {
@@ -426,15 +415,14 @@ export default function GoalsTracker({ networth }: Props) {
             const monthlyRate = daysTotal > 0 ? (goal.target_amount - goal.current_amount) / (daysTotal / 30) : 0;
 
             return (
-              <Card key={goal.id} className="relative overflow-hidden">
+              <div key={goal.id} className="glass-card p-5 relative overflow-hidden">
                 {/* Color accent bar */}
                 <div
                   className="absolute top-0 left-0 right-0 h-1"
                   style={{ backgroundColor: goal.color }}
                 />
 
-                <CardContent className="p-5 pt-6">
-                  <div className="flex items-start justify-between mb-4">
+                <div className="flex items-start justify-between mb-4">
                     <div className="flex items-center gap-3">
                       <div
                         className="p-2 rounded-lg"
@@ -537,8 +525,7 @@ export default function GoalsTracker({ networth }: Props) {
                       </button>
                     </div>
                   </div>
-                </CardContent>
-              </Card>
+                </div>
             );
           })}
         </div>
@@ -553,13 +540,12 @@ export default function GoalsTracker({ networth }: Props) {
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {completedGoals.map((goal) => (
-              <Card key={goal.id} className="opacity-75">
+              <div key={goal.id} className="glass-card p-5 opacity-75">
                 <div
                   className="absolute top-0 left-0 right-0 h-1"
                   style={{ backgroundColor: '#22c55e' }}
                 />
-                <CardContent className="p-5 pt-6">
-                  <div className="flex items-start justify-between">
+                <div className="flex items-start justify-between">
                     <div className="flex items-center gap-3">
                       <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
                         {ICON_MAP[goal.icon] || ICON_MAP.target}
@@ -588,8 +574,7 @@ export default function GoalsTracker({ networth }: Props) {
                       </button>
                     </div>
                   </div>
-                </CardContent>
-              </Card>
+                </div>
             ))}
           </div>
         </div>
@@ -597,15 +582,12 @@ export default function GoalsTracker({ networth }: Props) {
 
       {/* Networth Context */}
       {latestNetworth && activeGoals.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Networth Context</CardTitle>
-            <CardDescription className="text-xs">
+        <div className="glass-card p-5">
+          <h3 className="text-sm font-medium text-white/80">Networth Context</h3>
+            <p className="text-xs text-white/50">
               Your latest networth compared to your goals
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Current Networth</p>
                 <p className="text-lg font-bold">{formatIdr(latestNetworth.total)}</p>
@@ -621,8 +603,7 @@ export default function GoalsTracker({ networth }: Props) {
                 </p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
 
       {/* Create/Edit Dialog */}

--- a/src/components/HealthScore.tsx
+++ b/src/components/HealthScore.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import type { MonthlySummary, Category } from '../lib/data';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Select,
@@ -294,13 +293,13 @@ export default function HealthScore({ summaries, categories }: Props) {
 
   if (!healthData) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
+      <div className="glass-card p-5">
+        
           <Heart className="mx-auto h-12 w-12 text-white/30 mb-4" />
           <p className="text-white/50">Not enough data to calculate health score.</p>
           <p className="text-sm text-white/40 mt-1">Add transactions and income data to get started.</p>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
@@ -397,14 +396,14 @@ export default function HealthScore({ summaries, categories }: Props) {
 
       {/* Improvement Tips */}
       {healthData.tips.length > 0 && (
-        <Card className="border-indigo-200 dark:border-indigo-900 bg-indigo-50/50 dark:bg-indigo-950/20">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-base">
+        <div className="glass-card p-5 border-indigo-200 dark:border-indigo-900 bg-indigo-50/50 dark:bg-indigo-950/20">
+          
+            <h3 className="flex items-center gap-2 text-base text-white/80">
               <Lightbulb className="h-5 w-5 text-indigo-500" />
               Improvement Tips
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
+            </h3>
+          
+          
             <ul className="space-y-2">
               {healthData.tips.map((tip, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm text-white/60">
@@ -413,16 +412,16 @@ export default function HealthScore({ summaries, categories }: Props) {
                 </li>
               ))}
             </ul>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* How it works */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">How is the score calculated?</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base text-white/80">How is the score calculated?</h3>
+        
+        
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-white/60">
             <div>
               <h4 className="font-medium text-white/70 mb-1">🎯 Savings Rate (0-20)</h4>
@@ -445,8 +444,8 @@ export default function HealthScore({ summaries, categories }: Props) {
               <p>Measures stability of savings rate over 3 months. Low variance = high score.</p>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
     </div>
   );
 }

--- a/src/components/ImportData.tsx
+++ b/src/components/ImportData.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
 import { importDataApi, type ImportResult } from '../lib/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -168,12 +167,9 @@ export default function ImportData() {
   const previewHeaders = previewRows.length > 0 ? Object.keys(previewRows[0]) : [];
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Import Data</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-2">
+    <div className="glass-card p-5">
+      <h3 className="text-white/80">Import Data</h3>
+      <div className="space-y-2">
           <Label htmlFor="import-file">File (JSON or CSV)</Label>
           <Input id="import-file" type="file" accept=".json,.csv" onChange={handleFileChange} />
         </div>
@@ -251,7 +247,6 @@ export default function ImportData() {
             {loading ? 'Importing...' : `Import ${allRows.length} Rows`}
           </Button>
         )}
-      </CardContent>
-    </Card>
+      </div>
   );
 }

--- a/src/components/IncomeSettings.tsx
+++ b/src/components/IncomeSettings.tsx
@@ -3,7 +3,6 @@ import type { MonthlyIncome } from '../lib/api';
 import { fetchMonthlyIncome, upsertMonthlyIncomeApi, updateMonthlyIncomeApi, deleteMonthlyIncomeApi } from '../lib/api';
 import { formatIdr } from '../lib/utils';
 import { useConfirm } from './ConfirmDialog';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -112,11 +111,11 @@ export default function IncomeSettings() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Monthly Income</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
+    <div className="glass-card p-5">
+      
+        <h3 className="text-white/80">Monthly Income</h3>
+      
+      
         {/* Add Form */}
         <form onSubmit={handleAdd} className="flex flex-col sm:flex-row gap-3 items-end">
           <div className="space-y-1.5 flex-1">
@@ -235,7 +234,7 @@ export default function IncomeSettings() {
             </Table>
           </div>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/MerchantAnalysis.tsx
+++ b/src/components/MerchantAnalysis.tsx
@@ -1,13 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import type { Transaction, MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Select,
@@ -341,63 +334,44 @@ export default function MerchantAnalysis({
 
       {/* Stats Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+        <div className="glass-card p-5">
+          <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5 text-white/80">
               <Store className="w-3.5 h-3.5" />
               Merchants
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">{stats.totalMerchants}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+            </h3>
+          <p className="text-2xl font-bold">{stats.totalMerchants}</p>
+          </div>
+        <div className="glass-card p-5">
+          <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5 text-white/80">
               <Hash className="w-3.5 h-3.5" />
               Transactions
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">{stats.totalTransactions}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+            </h3>
+          <p className="text-2xl font-bold">{stats.totalTransactions}</p>
+          </div>
+        <div className="glass-card p-5">
+          <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5 text-white/80">
               <BarChart3 className="w-3.5 h-3.5" />
               Total Spent
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-lg font-bold text-slate-800 dark:text-slate-100">
+            </h3>
+          <p className="text-lg font-bold text-slate-800 dark:text-slate-100">
               {formatIdr(stats.totalSpent)}
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+          </div>
+        <div className="glass-card p-5">
+          <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5 text-white/80">
               <TrendingUp className="w-3.5 h-3.5" />
               Avg / Merchant
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-lg font-bold">
+            </h3>
+          <p className="text-lg font-bold">
               {formatIdr(stats.avgPerMerchant)}
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+          </div>
+        <div className="glass-card p-5">
+          <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 flex items-center gap-1.5 text-white/80">
               <Sparkles className="w-3.5 h-3.5" />
               Top Merchant
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate" title={stats.topMerchant?.title}>
+            </h3>
+          <p className="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate" title={stats.topMerchant?.title}>
               {stats.topMerchant?.title ?? '—'}
             </p>
             {stats.topMerchant && (
@@ -405,24 +379,20 @@ export default function MerchantAnalysis({
                 {formatIdr(stats.topMerchant.totalPaid)}
               </p>
             )}
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* New Merchants Alert */}
       {newMerchants.length > 0 && viewMode === 'period' && (
-        <Card className="border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-semibold text-amber-800 dark:text-amber-300 flex items-center gap-2">
+        <div className="glass-card p-5 border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300 flex items-center gap-2 text-white/80">
               <Sparkles className="w-4 h-4" />
               New Merchants This Period
-            </CardTitle>
-            <CardDescription className="text-xs text-amber-600 dark:text-amber-400">
+            </h3>
+            <p className="text-xs text-amber-600 dark:text-amber-400 text-white/50">
               {newMerchants.length} merchant{newMerchants.length !== 1 ? 's' : ''} appearing for the first time
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
+            </p>
+          <div className="flex flex-wrap gap-2">
               {newMerchants.slice(0, 15).map((m) => (
                 <Badge
                   key={m.title}
@@ -441,30 +411,26 @@ export default function MerchantAnalysis({
                 </Badge>
               )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
 
       {/* Merchant Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
+      <div className="glass-card p-5">
+        <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+              <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <Store className="w-4 h-4 text-slate-500" />
                 {viewMode === 'period'
                   ? `Merchants — ${selectedPeriodLabel}`
                   : 'All-Time Merchant Summary'}
-              </CardTitle>
-              <CardDescription className="text-xs mt-0.5">
+              </h3>
+              <p className="text-xs mt-0.5 text-white/50">
                 {sortedMerchants.length} merchant{sortedMerchants.length !== 1 ? 's' : ''}
                 {selectedCategory !== 'all' && ` in "${selectedCategory}"`}
-              </CardDescription>
+              </p>
             </div>
           </div>
-        </CardHeader>
-        <CardContent className="pt-0">
-          {sortedMerchants.length === 0 ? (
+        {sortedMerchants.length === 0 ? (
             <div className="text-center py-12">
               <Store className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
               <p className="text-slate-500 dark:text-slate-400 text-sm">
@@ -580,23 +546,19 @@ export default function MerchantAnalysis({
               </Table>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
 
       {/* All-Time: Most Frequent Merchants */}
       {viewMode === 'all' && frequentMerchants.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base font-semibold flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
               <Clock className="w-4 h-4 text-slate-500" />
               Most Frequent Merchants
-            </CardTitle>
-            <CardDescription className="text-xs">
+            </h3>
+            <p className="text-xs text-white/50">
               Top 10 merchants by transaction count across all periods
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {frequentMerchants.map((m) => {
                 const maxCount = frequentMerchants[0]?.txCount ?? 1;
                 const barWidth = (m.txCount / maxCount) * 100;
@@ -630,8 +592,7 @@ export default function MerchantAnalysis({
                 );
               })}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       )}
     </div>
   );

--- a/src/components/MonthComparison.tsx
+++ b/src/components/MonthComparison.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import type { Transaction, NetworthRecord, MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -143,9 +142,8 @@ export default function MonthComparison({ transactions, networth, summaries, cat
     inverse?: boolean;
     format?: (n: number) => string;
   }) => (
-    <Card>
-      <CardContent className="pt-6">
-        <div className="flex items-center gap-2 mb-3">
+    <div className="glass-card p-5">
+      <div className="flex items-center gap-2 mb-3">
           <div className="p-1.5 rounded-md bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
             {icon}
           </div>
@@ -164,8 +162,7 @@ export default function MonthComparison({ transactions, networth, summaries, cat
             </div>
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
   );
 
   const handleSwap = () => {
@@ -262,15 +259,12 @@ export default function MonthComparison({ transactions, networth, summaries, cat
       </div>
 
       {/* Cash vs Credit Breakdown */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <CreditCard className="w-4 h-4 text-slate-500" />
             Cash vs Credit Breakdown
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {/* Left Month */}
             <div className="space-y-3">
               <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{leftMonth}</p>
@@ -308,8 +302,7 @@ export default function MonthComparison({ transactions, networth, summaries, cat
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Category Radar Chart */}
       <CategoryRadarChart
@@ -321,15 +314,12 @@ export default function MonthComparison({ transactions, networth, summaries, cat
       />
 
       {/* Category Comparison Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <TrendingDown className="w-4 h-4 text-slate-500" />
             Category Comparison
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="rounded-xl border overflow-hidden">
+          </h3>
+        <div className="rounded-xl border overflow-hidden">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -401,17 +391,13 @@ export default function MonthComparison({ transactions, networth, summaries, cat
               </TableBody>
             </Table>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Top Transactions */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base font-semibold">Top Transactions — {leftMonth}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base font-semibold text-white/80">Top Transactions — {leftMonth}</h3>
+          <div className="space-y-2">
               {[...leftTxs]
                 .sort((a, b) => b.amount - a.amount)
                 .slice(0, 5)
@@ -428,14 +414,10 @@ export default function MonthComparison({ transactions, networth, summaries, cat
                 <p className="text-sm text-white/30 text-center py-4">No transactions</p>
               )}
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base font-semibold">Top Transactions — {rightMonth}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
+          </div>
+        <div className="glass-card p-5">
+          <h3 className="text-base font-semibold text-white/80">Top Transactions — {rightMonth}</h3>
+          <div className="space-y-2">
               {[...rightTxs]
                 .sort((a, b) => b.amount - a.amount)
                 .slice(0, 5)
@@ -452,8 +434,7 @@ export default function MonthComparison({ transactions, networth, summaries, cat
                 <p className="text-sm text-white/30 text-center py-4">No transactions</p>
               )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
     </div>
   );

--- a/src/components/MonthlyReport.tsx
+++ b/src/components/MonthlyReport.tsx
@@ -1,12 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import type { Transaction, NetworthRecord, MonthlySummary, Category } from '../lib/data';
 import { formatIdr, getActivePeriodMonth } from '../lib/utils';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -200,26 +194,19 @@ export default function MonthlyReport({
 
         {/* Summary Cards */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 print:grid-cols-4">
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2 print:pb-1">
-              <CardTitle className="text-sm font-medium text-white/50 print:text-gray-600">
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-sm font-medium text-white/50 print:text-gray-600 text-white/80">
                 Total Income
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 print:text-emerald-700">
+              </h3>
+            <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 print:text-emerald-700">
                 {formatIdr(income)}
               </p>
-            </CardContent>
-          </Card>
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2 print:pb-1">
-              <CardTitle className="text-sm font-medium text-white/50 print:text-gray-600">
+            </div>
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-sm font-medium text-white/50 print:text-gray-600 text-white/80">
                 Total Outcome
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-2xl font-bold text-red-600 dark:text-red-400 print:text-red-700">
+              </h3>
+            <p className="text-2xl font-bold text-red-600 dark:text-red-400 print:text-red-700">
                 {formatIdr(totalOutcome)}
               </p>
               <div className="text-xs text-white/40 mt-1 print:text-gray-500">
@@ -230,16 +217,12 @@ export default function MonthlyReport({
                   Credit Pay: {formatIdr(reportSummary.outcome.credit_payment)}
                 </span>
               </div>
-            </CardContent>
-          </Card>
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2 print:pb-1">
-              <CardTitle className="text-sm font-medium text-white/50 print:text-gray-600">
+            </div>
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-sm font-medium text-white/50 print:text-gray-600 text-white/80">
                 Savings
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p
+              </h3>
+            <p
                 className={`text-2xl font-bold ${
                   reportSummary.savings >= 0
                     ? 'text-emerald-600 dark:text-emerald-400 print:text-emerald-700'
@@ -248,16 +231,12 @@ export default function MonthlyReport({
               >
                 {formatIdr(reportSummary.savings)}
               </p>
-            </CardContent>
-          </Card>
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2 print:pb-1">
-              <CardTitle className="text-sm font-medium text-white/50 print:text-gray-600">
+            </div>
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-sm font-medium text-white/50 print:text-gray-600 text-white/80">
                 Savings Rate
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p
+              </h3>
+            <p
                 className={`text-2xl font-bold ${
                   reportSummary.savings_rate_pct >= 20
                     ? 'text-emerald-600 dark:text-emerald-400 print:text-emerald-700'
@@ -268,21 +247,17 @@ export default function MonthlyReport({
               >
                 {reportSummary.savings_rate_pct.toFixed(1)}%
               </p>
-            </CardContent>
-          </Card>
+            </div>
         </div>
 
         {/* Period-over-Period Comparison */}
         {prevSummary && (
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <ArrowRight className="w-4 h-4" />
                 vs Previous Period ({prevSummary.month})
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+              </h3>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
                 {(() => {
                   const incomeChange = prevSummary.income > 0
                     ? ((income - prevSummary.income) / prevSummary.income) * 100
@@ -378,21 +353,17 @@ export default function MonthlyReport({
                   );
                 })()}
               </div>
-            </CardContent>
-          </Card>
+            </div>
         )}
 
         {/* Two-column: Category Breakdown + Net Worth */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 print:grid-cols-3">
           {/* Category Breakdown */}
-          <Card className="lg:col-span-2 print:col-span-2 print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold">
+          <div className="glass-card p-5 lg:col-span-2 print:col-span-2 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-base font-semibold text-white/80">
                 Category Breakdown
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {categoryBreakdown.length === 0 ? (
+              </h3>
+            {categoryBreakdown.length === 0 ? (
                 <p className="text-sm text-white/50">No category data.</p>
               ) : (
                 <Table>
@@ -464,18 +435,14 @@ export default function MonthlyReport({
                   </TableBody>
                 </Table>
               )}
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Net Worth Snapshot */}
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold">
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-base font-semibold text-white/80">
                 Net Worth
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {reportNetworth ? (
+              </h3>
+            {reportNetworth ? (
                 <div className="space-y-3">
                   <div>
                     <p className="text-xs text-white/50 print:text-gray-600">
@@ -547,19 +514,15 @@ export default function MonthlyReport({
                   No net worth data for this period.
                 </p>
               )}
-            </CardContent>
-          </Card>
+            </div>
         </div>
 
         {/* Top Transactions */}
-        <Card className="print:border print:border-gray-300 print:shadow-none">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base font-semibold">
+        <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+          <h3 className="text-base font-semibold text-white/80">
               Top 10 Transactions
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {topTransactions.length === 0 ? (
+            </h3>
+          {topTransactions.length === 0 ? (
               <p className="text-sm text-white/50">No transactions.</p>
             ) : (
               <Table>
@@ -612,20 +575,16 @@ export default function MonthlyReport({
                 </TableBody>
               </Table>
             )}
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Anomalies */}
         {anomalies.length > 0 && (
-          <Card className="print:border print:border-gray-300 print:shadow-none">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <AlertTriangle className="w-4 h-4 text-amber-500" />
                 Spending Anomalies
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
+              </h3>
+            <div className="space-y-3">
                 {anomalies.map((a) => {
                   const severityColor =
                     a.severity === 'high'
@@ -663,19 +622,15 @@ export default function MonthlyReport({
                   );
                 })}
               </div>
-            </CardContent>
-          </Card>
+            </div>
         )}
 
         {/* Transaction Summary Stats */}
-        <Card className="print:border print:border-gray-300 print:shadow-none">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base font-semibold">
+        <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
+          <h3 className="text-base font-semibold text-white/80">
               Transaction Summary
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+            </h3>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
               <div>
                 <p className="text-xs text-white/50 print:text-gray-600">
                   Total Transactions
@@ -717,8 +672,7 @@ export default function MonthlyReport({
                 </p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Footer */}
         <div className="text-center text-xs text-white/40 pt-4 border-t border-white/[0.06] print:text-gray-500 print:border-gray-300">

--- a/src/components/NetworthEditForm.tsx
+++ b/src/components/NetworthEditForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { fetchNetworth, updateNetworthApi } from '../lib/api';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -61,11 +60,11 @@ export default function NetworthEditForm() {
   }
 
   return (
-    <Card className="max-w-xl">
-      <CardHeader>
-        <CardTitle>Edit Networth</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="glass-card p-5 max-w-xl">
+      
+        <h3 className="text-white/80">Edit Networth</h3>
+      
+      
         <form onSubmit={handleSubmit} className="space-y-4">
           {message && (
             <Badge variant="outline" className="w-full justify-start px-3 py-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-800">
@@ -133,7 +132,7 @@ export default function NetworthEditForm() {
             </Button>
           </div>
         </form>
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/NetworthProjection.tsx
+++ b/src/components/NetworthProjection.tsx
@@ -13,7 +13,6 @@ import {
 import { Line } from 'react-chartjs-2';
 import type { NetworthRecord } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, Calendar, PiggyBank, Percent } from 'lucide-react';
@@ -181,11 +180,11 @@ export default function NetworthProjection({ data }: Props) {
 
   if (sortedData.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-8 text-center text-sm text-white/50">
+      <div className="glass-card p-5">
+        
           Add net worth data to see projections.
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
@@ -194,14 +193,14 @@ export default function NetworthProjection({ data }: Props) {
   return (
     <div className="space-y-6">
       {/* Controls */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <TrendingUp className="w-4 h-4 text-violet-500" />
             Projection Settings
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+          </h3>
+        
+        
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Projection length */}
             <div className="space-y-2">
@@ -289,41 +288,41 @@ export default function NetworthProjection({ data }: Props) {
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Projection Chart */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <TrendingUp className="w-4 h-4 text-violet-500" />
             Net Worth Projection
-          </CardTitle>
+          </h3>
           <p className="text-xs text-white/50">
             Solid line = historical. Dashed amber line = projected with {effectiveContribution > 0 ? `${formatIdr(effectiveContribution)}/mo contributions` : 'no additional contributions'} and {annualReturnRate}% annual return.
           </p>
-        </CardHeader>
-        <CardContent>
+        
+        
           <div className="h-[350px]">
             <Line data={chartData} options={chartOptions} />
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Summary Stats */}
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Card>
-            <CardContent className="pt-4 pb-4">
+          <div className="glass-card p-5">
+            
               <p className="text-xs text-white/50 mb-1">Current Net Worth</p>
               <p className="text-lg font-bold text-white/90">
                 {formatIdr(summary.lastValue)}
               </p>
-            </CardContent>
-          </Card>
+            
+          </div>
           {summary.at12 && (
-            <Card>
-              <CardContent className="pt-4 pb-4">
+            <div className="glass-card p-5">
+              
                 <p className="text-xs text-white/50 mb-1">In 12 Months</p>
                 <p className="text-lg font-bold text-amber-400">
                   {formatIdr(summary.at12)}
@@ -335,12 +334,12 @@ export default function NetworthProjection({ data }: Props) {
                     : 0}
                   %)
                 </p>
-              </CardContent>
-            </Card>
+              
+            </div>
           )}
           {summary.at24 && (
-            <Card>
-              <CardContent className="pt-4 pb-4">
+            <div className="glass-card p-5">
+              
                 <p className="text-xs text-white/50 mb-1">In 24 Months</p>
                 <p className="text-lg font-bold text-amber-400">
                   {formatIdr(summary.at24)}
@@ -352,12 +351,12 @@ export default function NetworthProjection({ data }: Props) {
                     : 0}
                   %)
                 </p>
-              </CardContent>
-            </Card>
+              
+            </div>
           )}
           {summary.at36 && (
-            <Card>
-              <CardContent className="pt-4 pb-4">
+            <div className="glass-card p-5">
+              
                 <p className="text-xs text-white/50 mb-1">In 36 Months</p>
                 <p className="text-lg font-bold text-amber-400">
                   {formatIdr(summary.at36)}
@@ -369,16 +368,16 @@ export default function NetworthProjection({ data }: Props) {
                     : 0}
                   %)
                 </p>
-              </CardContent>
-            </Card>
+              
+            </div>
           )}
         </div>
       )}
 
       {/* Breakdown */}
       {summary && summary.totalContributions > 0 && (
-        <Card>
-          <CardContent className="pt-4 pb-4">
+        <div className="glass-card p-5">
+          
             <div className="flex flex-wrap gap-6 text-sm">
               <div>
                 <span className="text-white/50">Total contributions: </span>
@@ -398,8 +397,8 @@ export default function NetworthProjection({ data }: Props) {
                 </span>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
     </div>
   );

--- a/src/components/PortfolioTracker.tsx
+++ b/src/components/PortfolioTracker.tsx
@@ -41,7 +41,6 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useSortState } from '../hooks/useSortState';
 import SortableHeader from './SortableHeader';
 import {
@@ -289,25 +288,20 @@ export default function PortfolioTracker() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
-        <Card>
-          <CardContent className="p-4">
-            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Total Invested</p>
+        <div className="glass-card p-5">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Total Invested</p>
             <p className="text-lg font-bold text-slate-800 dark:text-slate-100">
               {formatIdr(summary?.totalInvested ?? 0)}
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Current Value</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Current Value</p>
             <p className="text-lg font-bold text-slate-800 dark:text-slate-100">
               {formatIdr(summary?.totalCurrentValue ?? 0)}
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Total Gain/Loss</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Total Gain/Loss</p>
             <div className="flex items-center gap-1.5">
               {(summary?.totalGainLoss ?? 0) >= 0 ? (
                 <TrendingUp className="w-4 h-4 text-emerald-500" />
@@ -322,11 +316,9 @@ export default function PortfolioTracker() {
                 {formatIdr(summary?.totalGainLoss ?? 0)}
               </p>
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Return</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Return</p>
             <p className={`text-lg font-bold ${
               (summary?.totalGainLossPct ?? 0) >= 0
                 ? 'text-emerald-600 dark:text-emerald-400'
@@ -335,44 +327,34 @@ export default function PortfolioTracker() {
               {(summary?.totalGainLossPct ?? 0) >= 0 ? '+' : ''}
               {(summary?.totalGainLossPct ?? 0).toFixed(2)}%
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Holdings</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Holdings</p>
             <p className="text-lg font-bold text-slate-800 dark:text-slate-100">
               {summary?.holdingsCount ?? 0}
             </p>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Allocation Chart + By-Type Breakdown */}
       {donutData && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <Card className="lg:col-span-1">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5 lg:col-span-1">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <PieChart className="w-4 h-4 text-slate-500" />
                 Allocation by Type
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="h-64">
+              </h3>
+            <div className="h-64">
                 <Doughnut data={donutData} options={donutOptions} />
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
-          <Card className="lg:col-span-2">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5 lg:col-span-2">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <Wallet className="w-4 h-4 text-slate-500" />
                 Breakdown by Type
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
+              </h3>
+            <div className="space-y-3">
                 {Object.entries(summary?.byType ?? {}).map(([type, data]) => {
                   const pct = summary && summary.totalCurrentValue > 0
                     ? (data.currentValue / summary.totalCurrentValue) * 100
@@ -426,27 +408,23 @@ export default function PortfolioTracker() {
                   );
                 })}
               </div>
-            </CardContent>
-          </Card>
+            </div>
         </div>
       )}
 
       {/* Investments Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex justify-between items-center">
-            <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        <div className="flex justify-between items-center">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
               <Wallet className="w-4 h-4 text-slate-500" />
               Holdings ({investments.length})
-            </CardTitle>
+            </h3>
             <Button size="sm" onClick={openAdd} className="bg-emerald-600 hover:bg-emerald-700 text-white">
               <Plus className="w-4 h-4 mr-1" />
               Add Holding
             </Button>
           </div>
-        </CardHeader>
-        <CardContent className="pt-0">
-          {investments.length === 0 ? (
+        {investments.length === 0 ? (
             <div className="text-center py-12 text-slate-500 dark:text-slate-400">
               <Wallet className="w-10 h-10 mx-auto mb-3 opacity-30" />
               <p className="text-sm font-medium">No investments tracked yet</p>
@@ -548,8 +526,7 @@ export default function PortfolioTracker() {
               </Table>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Add/Edit Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>

--- a/src/components/RecurringBreakdown.tsx
+++ b/src/components/RecurringBreakdown.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Select,
@@ -228,14 +227,11 @@ export default function RecurringBreakdown() {
       {/* Summary Cards Row */}
       {currentPeriod && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-white/40">
+          <div className="glass-card p-5">
+            <h3 className="text-sm font-medium text-white/40 text-white/80">
                 Flexibility Score
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
+              </h3>
+            <div className="text-2xl font-bold">
                 {currentPeriod.discretionary_pct}%
               </div>
               <p className="text-xs text-white/30 mt-1">
@@ -264,74 +260,58 @@ export default function RecurringBreakdown() {
                     : 'Stable'}
                 </Badge>
               )}
-            </CardContent>
-          </Card>
+            </div>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-white/40">
+          <div className="glass-card p-5">
+            <h3 className="text-sm font-medium text-white/40 text-white/80">
                 Recurring
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+              </h3>
+            <div className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
                 {formatIdr(currentPeriod.recurring)}
               </div>
               <p className="text-xs text-white/30 mt-1">
                 {currentPeriod.recurring_count} transactions · {currentPeriod.recurring_pct}%
               </p>
-            </CardContent>
-          </Card>
+            </div>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-white/40">
+          <div className="glass-card p-5">
+            <h3 className="text-sm font-medium text-white/40 text-white/80">
                 Discretionary
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
+              </h3>
+            <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
                 {formatIdr(currentPeriod.discretionary)}
               </div>
               <p className="text-xs text-white/30 mt-1">
                 {currentPeriod.discretionary_count} transactions · {currentPeriod.discretionary_pct}%
               </p>
-            </CardContent>
-          </Card>
+            </div>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-white/40">
+          <div className="glass-card p-5">
+            <h3 className="text-sm font-medium text-white/40 text-white/80">
                 Total Spending
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
+              </h3>
+            <div className="text-2xl font-bold">
                 {formatIdr(currentPeriod.total)}
               </div>
               <p className="text-xs text-white/30 mt-1">
                 {currentPeriod.month}
               </p>
-            </CardContent>
-          </Card>
+            </div>
         </div>
       )}
 
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Donut Chart */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               <Repeat className="w-4 h-4 text-indigo-500" />
               Current Breakdown
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               {currentPeriod?.month || 'Latest period'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {donutData ? (
+            </p>
+          {donutData ? (
               <div className="max-w-[280px] mx-auto" style={{ height: 280 }}>
                 <Doughnut
                   data={donutData}
@@ -373,22 +353,18 @@ export default function RecurringBreakdown() {
                 No spending data for this period
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Trend Line */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               <Zap className="w-4 h-4 text-amber-500" />
               Trend Over Time
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               How the recurring/discretionary mix has shifted
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {trendData ? (
+            </p>
+          {trendData ? (
               <div style={{ height: 300 }}>
                 <Line
                   data={trendData}
@@ -453,24 +429,20 @@ export default function RecurringBreakdown() {
                 Need at least 2 periods of data
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Top Recurring Expenses Table */}
       {data.topRecurring.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               <Repeat className="w-4 h-4 text-indigo-500" />
               Top Recurring Expenses (All Time)
-            </CardTitle>
-            <CardDescription>
+            </h3>
+            <p className="text-white/50">
               Highest total spending on recurring items across all periods
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Table>
+            </p>
+          <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>#</TableHead>
@@ -498,15 +470,13 @@ export default function RecurringBreakdown() {
                 ))}
               </TableBody>
             </Table>
-          </CardContent>
-        </Card>
+          </div>
       )}
 
       {/* No recurring data notice */}
       {data.topRecurring.length === 0 && (
-        <Card>
-          <CardContent className="py-8 text-center">
-            <Repeat className="w-12 h-12 mx-auto text-white/10 mb-3" />
+        <div className="glass-card p-5">
+          <Repeat className="w-12 h-12 mx-auto text-white/10 mb-3" />
             <p className="text-white/40 font-medium">
               No recurring transactions found
             </p>
@@ -517,8 +487,7 @@ export default function RecurringBreakdown() {
               </a>{' '}
               to see the breakdown between recurring and discretionary spending.
             </p>
-          </CardContent>
-        </Card>
+          </div>
       )}
     </div>
   );

--- a/src/components/RecurringCostAnalyzer.tsx
+++ b/src/components/RecurringCostAnalyzer.tsx
@@ -17,7 +17,6 @@ import {
   Legend,
 } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Table,
@@ -153,17 +152,15 @@ export default function RecurringCostAnalyzer() {
 
   if (!data || data.activeItems.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <RefreshCw className="w-10 h-10 mx-auto mb-3 text-slate-300" />
+      <div className="glass-card p-5">
+        <RefreshCw className="w-10 h-10 mx-auto mb-3 text-slate-300" />
           <p className="text-slate-500 dark:text-slate-400">
             No active recurring transactions found.
           </p>
           <p className="text-xs text-slate-400 mt-1">
             Add recurring transactions on the <a href="/recurring" className="text-blue-500 hover:underline">Recurring page</a> to see your subscription cost analysis.
           </p>
-        </CardContent>
-      </Card>
+        </div>
     );
   }
 
@@ -173,31 +170,26 @@ export default function RecurringCostAnalyzer() {
     <div className="space-y-6">
       {/* ─── Summary Cards ──────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card className="border-l-4 border-l-blue-500">
-          <CardContent className="pt-5 pb-4">
-            <div className="flex items-center justify-between mb-1">
+        <div className="glass-card p-5 border-l-4 border-l-blue-500">
+          <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Monthly Cost</span>
               <DollarSign className="w-4 h-4 text-blue-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{formatIdr(monthlyTotal)}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">per salary period</p>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card className="border-l-4 border-l-emerald-500">
-          <CardContent className="pt-5 pb-4">
-            <div className="flex items-center justify-between mb-1">
+        <div className="glass-card p-5 border-l-4 border-l-emerald-500">
+          <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Annual Cost</span>
               <Calendar className="w-4 h-4 text-emerald-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{formatIdr(annualTotal)}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">projected per year</p>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card className="border-l-4 border-l-amber-500">
-          <CardContent className="pt-5 pb-4">
-            <div className="flex items-center justify-between mb-1">
+        <div className="glass-card p-5 border-l-4 border-l-amber-500">
+          <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Active Items</span>
               <RefreshCw className="w-4 h-4 text-amber-500" />
             </div>
@@ -205,50 +197,40 @@ export default function RecurringCostAnalyzer() {
             <p className="text-[11px] text-slate-400 mt-0.5">
               {temporaryCount > 0 ? `${temporaryCount} temporary` : 'all permanent'}
             </p>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card className="border-l-4 border-l-violet-500">
-          <CardContent className="pt-5 pb-4">
-            <div className="flex items-center justify-between mb-1">
+        <div className="glass-card p-5 border-l-4 border-l-violet-500">
+          <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Avg / Item</span>
               <PieChart className="w-4 h-4 text-violet-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{formatIdr(avgPerItem)}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">monthly average</p>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ─── Category Breakdown + Insight ────────────────────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Donut chart */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-sm flex items-center gap-2 text-white/80">
               <PieChart className="w-4 h-4 text-slate-500" />
               Category Breakdown
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {donutData && (
+            </h3>
+          {donutData && (
               <div style={{ height: 300 }}>
                 <Doughnut data={donutData} options={donutOptions} />
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
 
         {/* Insights */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-sm flex items-center gap-2 text-white/80">
               <Lightbulb className="w-4 h-4 text-amber-500" />
               Cost Insights
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 pt-2">
-            {largestItem && (
+            </h3>
+          {largestItem && (
               <div className="rounded-lg bg-slate-50 dark:bg-slate-800/60 p-3 border border-slate-200 dark:border-slate-700">
                 <div className="flex items-center gap-2 mb-1">
                   <TrendingDown className="w-3.5 h-3.5 text-red-500" />
@@ -294,17 +276,13 @@ export default function RecurringCostAnalyzer() {
                 ))}
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ─── Category Bars ──────────────────────────────────────────────────── */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm">Category Cost Breakdown</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
+      <div className="glass-card p-5">
+        <h3 className="text-sm text-white/80">Category Cost Breakdown</h3>
+        <div className="space-y-3">
             {categoryEntries.map(([cat, amt], i) => {
               const pct = ((amt / monthlyTotal) * 100);
               return (
@@ -326,17 +304,15 @@ export default function RecurringCostAnalyzer() {
               );
             })}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ─── Items Table ─────────────────────────────────────────────────────── */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-sm flex items-center gap-2">
+      <div className="glass-card p-5">
+        <div className="flex items-center justify-between">
+            <h3 className="text-sm flex items-center gap-2 text-white/80">
               Recurring Items
               <Badge variant="secondary" className="text-xs">{displayItems.length}</Badge>
-            </CardTitle>
+            </h3>
             {data.pausedItems.length > 0 && (
               <button
                 onClick={() => setShowPaused(!showPaused)}
@@ -347,9 +323,7 @@ export default function RecurringCostAnalyzer() {
               </button>
             )}
           </div>
-        </CardHeader>
-        <CardContent>
-          <Table>
+        <Table>
             <TableHeader>
               <TableRow>
                 <TableHead>Title</TableHead>
@@ -404,8 +378,7 @@ export default function RecurringCostAnalyzer() {
               })}
             </TableBody>
           </Table>
-        </CardContent>
-      </Card>
+        </div>
     </div>
   );
 }

--- a/src/components/RecurringManager.tsx
+++ b/src/components/RecurringManager.tsx
@@ -3,7 +3,6 @@ import type { RecurringTransaction } from '../lib/data';
 import { fetchRecurringTransactions, createRecurringTransaction, updateRecurringTransactionApi, deleteRecurringTransactionApi } from '../lib/api';
 import { formatIdr } from '../lib/utils';
 import { useConfirm } from './ConfirmDialog';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -174,14 +173,14 @@ export default function RecurringManager() {
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Recurring Transactions</CardTitle>
+    <div className="glass-card p-5">
+      
+        <h3 className="text-white/80">Recurring Transactions</h3>
         <Button size="sm" onClick={() => setIsAdding((v) => !v)}>
           {isAdding ? 'Cancel' : '+ Add Recurring'}
         </Button>
-      </CardHeader>
-      <CardContent>
+      
+      
         {error && (
           <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
             {error}
@@ -440,7 +439,7 @@ export default function RecurringManager() {
             </TableBody>
           </Table>
         </div>
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/RunwayAnalysis.tsx
+++ b/src/components/RunwayAnalysis.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import Sparkline from './Sparkline';
 import { formatIdr } from '../lib/utils';
@@ -225,65 +224,65 @@ export default function RunwayAnalysis({ periodId, compact = false }: Props) {
 
   if (loading) {
     return (
-      <Card className="border-white/[0.06] shadow-none">
-        <CardContent className="p-5">
+      <div className="glass-card p-5 border-white/[0.06] shadow-none">
+        
           <div className="animate-pulse space-y-3">
             <div className="h-5 w-32 bg-white/[0.08] rounded" />
             <div className="h-40 w-40 mx-auto bg-white/[0.08] rounded-full" />
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
   if (error || !data) {
     return (
-      <Card className="border-white/[0.06] shadow-none">
-        <CardContent className="p-5">
+      <div className="glass-card p-5 border-white/[0.06] shadow-none">
+        
           <div className="flex items-center gap-2 text-white/50 text-sm">
             <AlertTriangle className="w-4 h-4" />
             <span>Gagal memuat data runway. Coba lagi nanti.</span>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
   // No data available
   if (data.total_assets === 0) {
     return (
-      <Card className="border-white/[0.06] shadow-none">
-        <CardContent className="p-5">
+      <div className="glass-card p-5 border-white/[0.06] shadow-none">
+        
           <div className="flex items-center gap-2 text-white/50 text-sm">
             <Droplet className="w-4 h-4" />
             <span>Belum ada data networth. Tambahkan data networth untuk menghitung runway.</span>
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
     );
   }
 
   return (
-    <Card className={`border ${config.borderColor} shadow-none`}>
-      <CardHeader className="pb-3">
+    <div className={`glass-card p-5 border ${config.borderColor} shadow-none`}>
+      
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div className={`p-1.5 rounded-lg ${config.bgColor} ${config.textColor}`}>
               {config.icon}
             </div>
             <div>
-              <CardTitle className="text-base">Emergency Fund Runway</CardTitle>
-              <CardDescription className="text-xs">
+              <h3 className="text-base text-white/80">Emergency Fund Runway</h3>
+              <p className="text-xs text-white/50">
                 {data.month ? `Periode ${data.month}` : 'Periode terbaru'}
-              </CardDescription>
+              </p>
             </div>
           </div>
           <Badge variant="outline" className={`${config.textColor} ${config.borderColor}`}>
             {config.label}
           </Badge>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
+      
+      
         {/* Gauge + key stats */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-center">
           <div className="flex justify-center">
@@ -366,7 +365,7 @@ export default function RunwayAnalysis({ periodId, compact = false }: Props) {
             <ArrowRight className="w-3 h-3" />
           </a>
         )}
-      </CardContent>
-    </Card>
+      
+    </div>
   );
 }

--- a/src/components/SafeToSpend.tsx
+++ b/src/components/SafeToSpend.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
 import { formatIdr } from '../lib/utils';
 import { TrendingUp, TrendingDown, Minus, CalendarClock, Wallet, Flame } from 'lucide-react';
 
@@ -84,11 +83,9 @@ export default function SafeToSpend({ periodId }: Props) {
   // Loading skeleton — must render consistently to avoid hydration issues
   if (loading) {
     return (
-      <Card className="border-slate-200 dark:border-slate-700 shadow-none animate-pulse">
-        <CardContent className="p-5">
-          <div className="h-24 bg-slate-100 dark:bg-slate-800 rounded-lg" />
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5 border-slate-200 dark:border-slate-700 shadow-none animate-pulse">
+        <div className="h-24 bg-slate-100 dark:bg-slate-800 rounded-lg" />
+        </div>
     );
   }
 
@@ -108,12 +105,11 @@ export default function SafeToSpend({ periodId }: Props) {
     : 0;
 
   return (
-    <Card className={`bg-card relative overflow-hidden border ${cfg.border} shadow-none`}>
+    <div className="glass-card p-5" className={`bg-card relative overflow-hidden border ${cfg.border} shadow-none`}>
       {/* Top accent bar */}
       <div className={`absolute top-0 left-0 right-0 h-1 ${cfg.accent}`} />
 
-      <CardContent className="p-5 pt-6">
-        <div className="flex flex-col sm:flex-row items-start gap-4">
+      <div className="flex flex-col sm:flex-row items-start gap-4">
           {/* Left: Big Number */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
@@ -207,7 +203,6 @@ export default function SafeToSpend({ periodId }: Props) {
             />
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
   );
 }

--- a/src/components/SpendingCalendar.tsx
+++ b/src/components/SpendingCalendar.tsx
@@ -37,12 +37,14 @@ interface Props {
   periods?: PeriodOption[];
 }
 
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
 function parseMonthYear(monthStr: string): { year: number; monthIndex: number } {
   const d = new Date(`${monthStr} 1`);
   if (!isNaN(d.getTime())) {
     return { year: d.getFullYear(), monthIndex: d.getMonth() };
   }
-  // Fallback: try to parse manually
   const parts = monthStr.split(' ');
   const monthNames = [
     'january','february','march','april','may','june',
@@ -57,41 +59,26 @@ function parseMonthYear(monthStr: string): { year: number; monthIndex: number } 
   return { year: now.getFullYear(), monthIndex: now.getMonth() };
 }
 
-function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-function getFirstDayOfMonth(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
-}
-
-function formatDateKey(year: number, month: number, day: number): string {
-  const m = String(month + 1).padStart(2, '0');
-  const d = String(day).padStart(2, '0');
-  return `${year}-${m}-${d}`;
-}
-
-function parseTxDate(tx: Transaction): string | null {
-  // created_time is the actual transaction timestamp; date is just the period start (always 1st)
-  const raw = tx.created_time || tx.date;
-  if (!raw) return null;
-  const d = new Date(raw);
-  if (isNaN(d.getTime())) return null;
+function dateKey(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
 }
 
-const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+function parseTxDate(tx: Transaction): string | null {
+  const raw = tx.created_time || tx.date;
+  if (!raw) return null;
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return null;
+  return dateKey(d);
+}
 
 export default function SpendingCalendar({ transactions, periods }: Props) {
-  // Build month options from periods prop (post-migration: transactions have no month column)
   const monthOptions = useMemo(() => {
     if (periods && periods.length > 0) {
       return [...periods].reverse().map((p) => p.month);
     }
-    // Fallback: derive from created_time dates when periods not provided
     const set = new Set<string>();
     const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
     transactions.forEach((t) => {
@@ -110,55 +97,76 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
   }, [transactions, periods]);
 
   const [selectedMonth, setSelectedMonth] = useState<string>(() => {
-    if (monthOptions.length > 0) return monthOptions[monthOptions.length - 1];
+    if (monthOptions.length > 0) return monthOptions[0];
     const now = new Date();
     return `${now.toLocaleDateString('en-US', { month: 'long' })} ${now.getFullYear()}`;
   });
 
   useEffect(() => {
     if (monthOptions.length > 0 && !monthOptions.includes(selectedMonth)) {
-      setSelectedMonth(monthOptions[monthOptions.length - 1]);
+      setSelectedMonth(monthOptions[0]);
     }
   }, [monthOptions, selectedMonth]);
 
   const { year, monthIndex } = useMemo(() => parseMonthYear(selectedMonth), [selectedMonth]);
 
-  const daysInMonth = useMemo(() => getDaysInMonth(year, monthIndex), [year, monthIndex]);
-  const firstDay = useMemo(() => getFirstDayOfMonth(year, monthIndex), [year, monthIndex]);
+  // ── Period range: 21st of previous month → 20th of selected month ──
+  const periodDates = useMemo(() => {
+    const prevMonth = monthIndex === 0 ? 11 : monthIndex - 1;
+    const prevMonthYear = monthIndex === 0 ? year - 1 : year;
+    const start = new Date(prevMonthYear, prevMonth, 21);
+    const end = new Date(year, monthIndex, 20);
 
-  // Find the period_id for the selected month
+    const dates: Date[] = [];
+    const cur = new Date(start);
+    while (cur <= end) {
+      dates.push(new Date(cur));
+      cur.setDate(cur.getDate() + 1);
+    }
+    return dates;
+  }, [year, monthIndex]);
+
+  const periodLabel = useMemo(() => {
+    if (periodDates.length === 0) return selectedMonth;
+    const first = periodDates[0];
+    const last = periodDates[periodDates.length - 1];
+    return `${MONTH_ABBR[first.getMonth()]} ${first.getDate()} – ${MONTH_ABBR[last.getMonth()]} ${last.getDate()}`;
+  }, [periodDates, selectedMonth]);
+
   const selectedPeriodId = useMemo(() => {
     if (!periods) return null;
     const match = periods.find((p) => p.month === selectedMonth);
     return match ? match.period_id : null;
   }, [periods, selectedMonth]);
 
-  // Filter transactions to the selected period (by period_id when available, fallback to date matching)
   const periodTransactions = useMemo(() => {
     if (selectedPeriodId !== null) {
       return transactions.filter((t) => t.period_id === selectedPeriodId);
     }
-    // Fallback: match by created_time month/year
     return transactions.filter((tx) => {
       const raw = tx.created_time || tx.date || '';
       const d = new Date(raw);
       if (isNaN(d.getTime())) return false;
-      return d.getFullYear() === year && d.getMonth() === monthIndex;
+      // Salary period: 21st of prev month to 20th of current
+      const prevMonth = monthIndex === 0 ? 11 : monthIndex - 1;
+      const prevMonthYear = monthIndex === 0 ? year - 1 : year;
+      const start = new Date(prevMonthYear, prevMonth, 21);
+      const end = new Date(year, monthIndex, 20, 23, 59, 59);
+      return d >= start && d <= end;
     });
   }, [transactions, selectedPeriodId, year, monthIndex]);
 
   const dailyTotals = useMemo(() => {
     const map: Record<string, { total: number; count: number; transactions: Transaction[] }> = {};
     periodTransactions.forEach((tx) => {
-      const dateKey = parseTxDate(tx);
-      if (!dateKey) return;
-
-      if (!map[dateKey]) {
-        map[dateKey] = { total: 0, count: 0, transactions: [] };
+      const dKey = parseTxDate(tx);
+      if (!dKey) return;
+      if (!map[dKey]) {
+        map[dKey] = { total: 0, count: 0, transactions: [] };
       }
-      map[dateKey].total += tx.amount;
-      map[dateKey].count += 1;
-      map[dateKey].transactions.push(tx);
+      map[dKey].total += tx.amount;
+      map[dKey].count += 1;
+      map[dKey].transactions.push(tx);
     });
     return map;
   }, [periodTransactions]);
@@ -169,15 +177,21 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
   }, [dailyTotals]);
 
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedDay, setSelectedDay] = useState<number | null>(null);
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
 
-  const openDay = (day: number) => {
-    setSelectedDay(day);
+  const openDay = (dKey: string) => {
+    setSelectedDateKey(dKey);
     setDialogOpen(true);
   };
 
-  const selectedDayKey = selectedDay != null ? formatDateKey(year, monthIndex, selectedDay) : null;
-  const selectedDayData = selectedDayKey ? dailyTotals[selectedDayKey] : null;
+  const selectedDayData = selectedDateKey ? dailyTotals[selectedDateKey] : null;
+
+  const selectedDateLabel = useMemo(() => {
+    if (!selectedDateKey) return '';
+    const d = new Date(selectedDateKey + 'T00:00:00');
+    if (isNaN(d.getTime())) return selectedDateKey;
+    return `${MONTH_ABBR[d.getMonth()]} ${d.getDate()}`;
+  }, [selectedDateKey]);
 
   const goToPrevMonth = () => {
     const idx = monthOptions.indexOf(selectedMonth);
@@ -199,13 +213,13 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
     return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
   };
 
-  const days: (number | null)[] = [];
-  for (let i = 0; i < firstDay; i++) days.push(null);
-  for (let d = 1; d <= daysInMonth; d++) days.push(d);
+  // Grid: leading nulls for weekday alignment, then all period dates
+  const firstDayOfWeek = periodDates.length > 0 ? periodDates[0].getDay() : 0;
+  const cells: (Date | null)[] = [];
+  for (let i = 0; i < firstDayOfWeek; i++) cells.push(null);
+  cells.push(...periodDates);
 
-  const today = new Date();
-  const isCurrentMonth = today.getFullYear() === year && today.getMonth() === monthIndex;
-  const todayDay = today.getDate();
+  const todayKey = dateKey(new Date());
 
   return (
     <div className="space-y-6">
@@ -258,82 +272,89 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
       {/* Calendar Grid */}
       <div className="glass-card p-5">
         <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <CalendarDays className="w-4 h-4 text-white/40" />
-            Spending Heatmap — {selectedMonth}
-            {selectedPeriodId && (
-              <span className="text-xs font-normal text-white/40">
-                (Period transactions)
-              </span>
-            )}
-          </h3>
-        <div className="grid grid-cols-7 gap-1">
-            {WEEKDAYS.map((wd) => (
-              <div key={wd} className="text-center text-xs font-medium text-white/30 py-2">
-                {wd}
-              </div>
-            ))}
-            {days.map((day, idx) => {
-              if (day === null) {
-                return <div key={`empty-${idx}`} className="aspect-square" />;
-              }
-              const dateKey = formatDateKey(year, monthIndex, day);
-              const data = dailyTotals[dateKey];
-              const total = data?.total ?? 0;
-              const count = data?.count ?? 0;
-              const isToday = isCurrentMonth && day === todayDay;
-              const heatClass = getHeatColor(total);
+          <CalendarDays className="w-4 h-4 text-white/40" />
+          Spending Heatmap — {periodLabel}
+          <span className="text-xs font-normal text-white/30">
+            ({selectedMonth} salary period)
+          </span>
+        </h3>
+        <div className="grid grid-cols-7 gap-1 mt-4">
+          {WEEKDAYS.map((wd) => (
+            <div key={wd} className="text-center text-xs font-medium text-white/30 py-2">
+              {wd}
+            </div>
+          ))}
+          {cells.map((date, idx) => {
+            if (date === null) {
+              return <div key={`empty-${idx}`} className="aspect-square" />;
+            }
+            const dKey = dateKey(date);
+            const data = dailyTotals[dKey];
+            const total = data?.total ?? 0;
+            const count = data?.count ?? 0;
+            const isToday = dKey === todayKey;
+            const heatClass = getHeatColor(total);
+            // Show month abbreviation on period start (21st) and month boundary (1st)
+            const showMonthLabel = date.getDate() === 21 || date.getDate() === 1;
+            const isMonthBoundary = date.getDate() === 1;
 
-              return (
-                <button
-                  key={day}
-                  onClick={() => openDay(day)}
-                  className={`
-                    aspect-square rounded-lg border transition-all hover:scale-105 hover:shadow-sm
-                    flex flex-col items-center justify-center gap-0.5
-                    ${heatClass}
-                    ${isToday ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-navy-950' : 'border-white/[0.06]'}
-                    ${count > 0 ? 'cursor-pointer' : 'cursor-default'}
-                  `}
-                >
-                  <span className={`text-xs font-medium ${isToday ? 'text-blue-400' : ''}`}>
-                    {day}
+            return (
+              <button
+                key={dKey}
+                onClick={() => count > 0 && openDay(dKey)}
+                className={`
+                  aspect-square rounded-lg border transition-all hover:scale-105 hover:shadow-sm
+                  flex flex-col items-center justify-center gap-0.5
+                  ${heatClass}
+                  ${isToday ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-navy-950' : 'border-white/[0.06]'}
+                  ${count > 0 ? 'cursor-pointer' : 'cursor-default'}
+                  ${isMonthBoundary ? 'ring-1 ring-white/10' : ''}
+                `}
+              >
+                <span className={`text-xs font-medium ${isToday ? 'text-blue-400' : ''}`}>
+                  {date.getDate()}
+                </span>
+                {showMonthLabel && (
+                  <span className="text-[8px] opacity-50 leading-none uppercase tracking-wide">
+                    {MONTH_ABBR[date.getMonth()]}
                   </span>
-                  {count > 0 && (
-                    <>
-                      <span className="text-[10px] font-semibold leading-none">
-                        {formatIdr(total)}
-                      </span>
-                      <span className="text-[9px] opacity-70 leading-none">
-                        {count} tx
-                      </span>
-                    </>
-                  )}
-                </button>
-              );
-            })}
-          </div>
+                )}
+                {count > 0 && (
+                  <>
+                    <span className="text-[10px] font-semibold leading-none">
+                      {formatIdr(total)}
+                    </span>
+                    <span className="text-[9px] opacity-70 leading-none">
+                      {count} tx
+                    </span>
+                  </>
+                )}
+              </button>
+            );
+          })}
         </div>
+      </div>
 
       {/* Monthly Summary */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <div className="glass-card p-5">
           <div className="text-xs text-white/40 mb-1">Days with Spending</div>
-            <div className="text-2xl font-semibold">
-              {Object.values(dailyTotals).filter((d) => d.total > 0).length}
-            </div>
+          <div className="text-2xl font-semibold">
+            {Object.values(dailyTotals).filter((d) => d.total > 0).length}
           </div>
+        </div>
         <div className="glass-card p-5">
           <div className="text-xs text-white/40 mb-1">Total Transactions</div>
-            <div className="text-2xl font-semibold">
-              {Object.values(dailyTotals).reduce((s, d) => s + d.count, 0)}
-            </div>
+          <div className="text-2xl font-semibold">
+            {Object.values(dailyTotals).reduce((s, d) => s + d.count, 0)}
           </div>
+        </div>
         <div className="glass-card p-5">
-          <div className="text-xs text-white/40 mb-1">Monthly Spend</div>
-            <div className="text-2xl font-semibold">
-              {formatIdr(Object.values(dailyTotals).reduce((s, d) => s + d.total, 0))}
-            </div>
+          <div className="text-xs text-white/40 mb-1">Period Spend</div>
+          <div className="text-2xl font-semibold">
+            {formatIdr(Object.values(dailyTotals).reduce((s, d) => s + d.total, 0))}
           </div>
+        </div>
       </div>
 
       {/* Day Detail Dialog */}
@@ -342,7 +363,7 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <CalendarDays className="w-5 h-5 text-white/40" />
-              {selectedMonth} {selectedDay}
+              {selectedDateLabel}
             </DialogTitle>
             <DialogDescription>
               {selectedDayData

--- a/src/components/SpendingCalendar.tsx
+++ b/src/components/SpendingCalendar.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import type { Transaction } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -257,9 +256,8 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
       </div>
 
       {/* Calendar Grid */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
             <CalendarDays className="w-4 h-4 text-white/40" />
             Spending Heatmap — {selectedMonth}
             {selectedPeriodId && (
@@ -267,10 +265,8 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
                 (Period transactions)
               </span>
             )}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-7 gap-1">
+          </h3>
+        <div className="grid grid-cols-7 gap-1">
             {WEEKDAYS.map((wd) => (
               <div key={wd} className="text-center text-xs font-medium text-white/30 py-2">
                 {wd}
@@ -316,35 +312,28 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
               );
             })}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* Monthly Summary */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-xs text-white/40 mb-1">Days with Spending</div>
+        <div className="glass-card p-5">
+          <div className="text-xs text-white/40 mb-1">Days with Spending</div>
             <div className="text-2xl font-semibold">
               {Object.values(dailyTotals).filter((d) => d.total > 0).length}
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-xs text-white/40 mb-1">Total Transactions</div>
+          </div>
+        <div className="glass-card p-5">
+          <div className="text-xs text-white/40 mb-1">Total Transactions</div>
             <div className="text-2xl font-semibold">
               {Object.values(dailyTotals).reduce((s, d) => s + d.count, 0)}
             </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-xs text-white/40 mb-1">Monthly Spend</div>
+          </div>
+        <div className="glass-card p-5">
+          <div className="text-xs text-white/40 mb-1">Monthly Spend</div>
             <div className="text-2xl font-semibold">
               {formatIdr(Object.values(dailyTotals).reduce((s, d) => s + d.total, 0))}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* Day Detail Dialog */}

--- a/src/components/SpendingDna.tsx
+++ b/src/components/SpendingDna.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   Chart as ChartJS,
@@ -370,9 +369,8 @@ export default function SpendingDna() {
   return (
     <div className="space-y-6">
       {/* ── Personality Type Hero ──────────────────────────────────────── */}
-      <Card className="border-violet-200 dark:border-violet-800 bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-slate-800 dark:to-slate-900">
-        <CardContent className="pt-6">
-          <div className="flex flex-col md:flex-row items-center gap-6">
+      <div className="glass-card p-5 border-violet-200 dark:border-violet-800 bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-slate-800 dark:to-slate-900">
+        <div className="flex flex-col md:flex-row items-center gap-6">
             <div className="text-7xl">{data.personality.emoji}</div>
             <div className="flex-1 text-center md:text-left">
               <h2 className="text-2xl font-bold text-violet-900 dark:text-violet-200">
@@ -400,34 +398,26 @@ export default function SpendingDna() {
               <Trophy className="w-16 h-16 text-violet-300 dark:text-violet-700" />
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ── Radar Chart + Dimension Breakdown ────────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               <Brain className="w-5 h-5 text-violet-500" />
               Behavioral Radar
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div style={{ height: 320, maxWidth: 380, margin: '0 auto' }}>
+            </h3>
+          <div style={{ height: 320, maxWidth: 380, margin: '0 auto' }}>
               {radarData && <Radar data={radarData} options={radarOptions} />}
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               <BarChart3 className="w-5 h-5 text-slate-500" />
               Dimension Breakdown
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
+            </h3>
+          <div className="space-y-4">
               {Object.entries(data.dimensions).map(([key, value]) => (
                 <div key={key}>
                   <div className="flex items-center justify-between mb-1">
@@ -446,20 +436,16 @@ export default function SpendingDna() {
                 </div>
               ))}
             </div>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ── Key Insights ──────────────────────────────────────────────── */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="flex items-center gap-2 text-white/80">
             <Zap className="w-5 h-5 text-amber-500" />
             Key Insights
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
+          </h3>
+        <div className="space-y-3">
             {data.insights.map((insight, i) => (
               <div
                 key={i}
@@ -470,20 +456,16 @@ export default function SpendingDna() {
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ── DNA Timeline Charts ──────────────────────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               <TrendingUp className="w-5 h-5 text-emerald-500" />
               Savings Rate Over Time
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {savingsChartData ? (
+            </h3>
+          {savingsChartData ? (
               <div style={{ height: 220 }}>
                 <Bar data={savingsChartData} options={savingsChartOptions} />
               </div>
@@ -492,18 +474,14 @@ export default function SpendingDna() {
                 No income data available for savings rate calculation
               </p>
             )}
-          </CardContent>
-        </Card>
+          </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="flex items-center gap-2 text-white/80">
               <Target className="w-5 h-5 text-pink-500" />
               Recurring vs Discretionary Split
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {compositionChartData ? (
+            </h3>
+          {compositionChartData ? (
               <div style={{ height: 220 }}>
                 <Bar data={compositionChartData} options={compositionChartOptions} />
               </div>
@@ -512,20 +490,16 @@ export default function SpendingDna() {
                 No spending data available
               </p>
             )}
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ── Timeline Sparkline Cards ─────────────────────────────────── */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="flex items-center gap-2 text-white/80">
             <Heart className="w-5 h-5 text-rose-500" />
             Monthly DNA Timeline
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+          </h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
             {data.timeline.slice(-12).map((entry) => (
               <div
                 key={entry.period_id}
@@ -556,22 +530,18 @@ export default function SpendingDna() {
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ── Category Loyalty Scores ──────────────────────────────────── */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+      <div className="glass-card p-5">
+        <h3 className="flex items-center gap-2 text-white/80">
             <Shield className="w-5 h-5 text-sky-500" />
             Category Loyalty Scores
-          </CardTitle>
+          </h3>
           <p className="text-xs text-slate-500">
             How consistent each category's spending is across periods (lower CV = more loyal)
           </p>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
+        <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-slate-200 dark:border-slate-700">
@@ -635,8 +605,7 @@ export default function SpendingDna() {
               </tbody>
             </table>
           </div>
-        </CardContent>
-      </Card>
+        </div>
     </div>
   );
 }

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -5,9 +5,10 @@ import { formatIdr } from '../lib/utils';
 import { useSortState } from '../hooks/useSortState';
 import SortableHeader from './SortableHeader';
 import EditTransactionDialog from './EditTransactionDialog';
-import { StickyNote } from 'lucide-react';
+import { StickyNote, Search, SlidersHorizontal, Download, X, Filter, ChevronDown } from 'lucide-react';
 import { useConfirm } from './ConfirmDialog';
 import { toast } from 'sonner';
+import { motion, AnimatePresence } from 'motion/react';
 import {
   Table,
   TableBody,
@@ -44,7 +45,7 @@ function parseCreatedTime(tx: Transaction): Date {
 
 export default function TransactionTable({ transactions, showMonth = true, periods = [] }: Props) {
   const { confirm: confirmAction } = useConfirm();
-  // Build lookup maps from periods
+
   const periodIdToMonth = useMemo(() => {
     const map = new Map<number, string>();
     periods.forEach((p) => map.set(p.period_id, p.month));
@@ -69,6 +70,7 @@ export default function TransactionTable({ transactions, showMonth = true, perio
       amountMax: params.get('amountMax') || '',
     };
   };
+
   const initial = getInitialState();
   const [page, setPage] = useState(initial.page);
   const [filterType, setFilterType] = useState<string>(initial.filterType);
@@ -83,6 +85,7 @@ export default function TransactionTable({ transactions, showMonth = true, perio
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bulkCategory, setBulkCategory] = useState<string>('');
   const [categories, setCategories] = useState<Category[]>([]);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const rowsPerPage = 25;
   const { toggleSort, sortData, isSorted } = useSortState();
 
@@ -126,9 +129,7 @@ export default function TransactionTable({ transactions, showMonth = true, perio
   }, [transactions, sortData, getCellValue]);
 
   let filtered = sorted;
-  if (filterType !== 'all') {
-    filtered = filtered.filter((t) => t.type === filterType);
-  }
+  if (filterType !== 'all') filtered = filtered.filter((t) => t.type === filterType);
   if (filterPeriodId !== 'all') {
     const pid = parseInt(filterPeriodId, 10);
     filtered = filtered.filter((t) => t.period_id === pid);
@@ -156,9 +157,35 @@ export default function TransactionTable({ transactions, showMonth = true, perio
     if (!isNaN(max)) filtered = filtered.filter((t) => t.amount <= max);
   }
 
+  const activeFilterCount = [
+    filterType !== 'all',
+    filterPeriodId !== 'all',
+    search.trim() !== '',
+    dateFrom !== '',
+    dateTo !== '',
+    amountMin !== '',
+    amountMax !== '',
+  ].filter(Boolean).length;
+
+  const hasAdvancedFilters = dateFrom || dateTo || amountMin || amountMax;
+
+  const clearFilters = () => {
+    setFilterType('all');
+    setFilterPeriodId('all');
+    setSearch('');
+    setDateFrom('');
+    setDateTo('');
+    setAmountMin('');
+    setAmountMax('');
+    setPage(1);
+    setAdvancedOpen(false);
+  };
+
   const totalPages = Math.max(1, Math.ceil(filtered.length / rowsPerPage));
   const safePage = Math.min(page, totalPages);
   const pageRows = filtered.slice((safePage - 1) * rowsPerPage, safePage * rowsPerPage);
+
+  // ── Bulk actions ───────────────────────────────────────────────
 
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
@@ -169,17 +196,13 @@ export default function TransactionTable({ transactions, showMonth = true, perio
   };
 
   const toggleSelectAll = () => {
-    if (selected.size === pageRows.length) {
-      setSelected(new Set());
-    } else {
-      setSelected(new Set(pageRows.map((r) => r.id)));
-    }
+    if (selected.size === pageRows.length) setSelected(new Set());
+    else setSelected(new Set(pageRows.map((r) => r.id)));
   };
 
   const handleSave = async () => {
     if (!editingId) return;
     const { id, ...updates } = editForm as any;
-    // Convert period_id to number if present
     if (updates.period_id) updates.period_id = Number(updates.period_id);
     await updateTransactionApi(editingId, updates);
     setEditingId(null);
@@ -209,251 +232,507 @@ export default function TransactionTable({ transactions, showMonth = true, perio
     window.location.reload();
   };
 
+  // ── Render ─────────────────────────────────────────────────────
+
   return (
     <div>
-      <div className="flex flex-col sm:flex-row gap-3 mb-4">
-        <Input
-          placeholder="Search title or category..."
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-          className="max-w-xs"
-        />
-        <Select value={filterType} onValueChange={(v) => { setFilterType(v); setPage(1); }}>
-          <SelectTrigger className="w-[140px]">
-            <SelectValue placeholder="All Types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Types</SelectItem>
-            <SelectItem value="cash">Cash</SelectItem>
-            <SelectItem value="credit_expense">Credit Expense</SelectItem>
-            <SelectItem value="credit_payment">Credit Payment</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select value={filterPeriodId} onValueChange={(v) => { setFilterPeriodId(v); setPage(1); }}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Periods" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Periods</SelectItem>
-            {monthOptions.map((p) => (
-              <SelectItem key={p.period_id} value={p.period_id.toString()}>{p.month}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            const exportData = filtered.map((t) => ({
-              date: t.date,
-              description: t.title,
-              amount: t.amount,
-              type: t.type,
-              category: t.category,
-              paid: t.done,
-              notes: t.notes || '',
-              period: periodIdToMonth.get(t.period_id) || '',
-            }));
-            if (exportData.length === 0) {
-              toast.info('No transactions found for this period');
-              return;
-            }
-            const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            const fileName = filterPeriodId !== 'all' ? `transactions-${filterPeriodId}.json` : 'transactions-all.json';
-            a.href = url;
-            a.download = fileName;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-          }}
-        >
-          Export JSON
-        </Button>
-      </div>
+      {/* ─── Filter Bar ────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 mb-5">
+        {/* Primary row: search + type + period + export */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          {/* Search */}
+          <div className="relative flex-1 max-w-sm">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30 pointer-events-none" />
+            <Input
+              placeholder="Search title, category, notes..."
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              className="pl-9 bg-white/[0.04] border-white/[0.08] text-white/80 placeholder:text-white/25 focus-visible:ring-emerald-500/30"
+            />
+            {search && (
+              <button
+                onClick={() => { setSearch(''); setPage(1); }}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 hover:text-white/60"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
 
-      <div className="flex flex-col sm:flex-row gap-3 mb-4">
-        <div className="flex gap-2 items-center">
-          <label className="text-xs text-white/50">From</label>
-          <Input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPage(1); }} className="w-auto text-xs" />
-          <label className="text-xs text-white/50">To</label>
-          <Input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPage(1); }} className="w-auto text-xs" />
-        </div>
-        <div className="flex gap-2 items-center">
-          <label className="text-xs text-white/50">Min</label>
-          <Input type="number" placeholder="Amount" value={amountMin} onChange={(e) => { setAmountMin(e.target.value); setPage(1); }} className="w-28 text-xs" />
-          <label className="text-xs text-white/50">Max</label>
-          <Input type="number" placeholder="Amount" value={amountMax} onChange={(e) => { setAmountMax(e.target.value); setPage(1); }} className="w-28 text-xs" />
-        </div>
-      </div>
+          {/* Type filter */}
+          <Select value={filterType} onValueChange={(v) => { setFilterType(v); setPage(1); }}>
+            <SelectTrigger className="w-[150px] bg-white/[0.04] border-white/[0.08] text-white/70">
+              <SelectValue placeholder="All Types" />
+            </SelectTrigger>
+            <SelectContent className="bg-navy-800 border-white/[0.08]">
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="cash">💵 Cash</SelectItem>
+              <SelectItem value="credit_expense">💳 Credit Expense</SelectItem>
+              <SelectItem value="credit_payment">🏦 Credit Payment</SelectItem>
+            </SelectContent>
+          </Select>
 
-      {selected.size > 0 && (
-        <div className="flex gap-2 mb-4 items-center">
-          <span className="text-xs text-white/50">{selected.size} selected</span>
-          <select
-            value={bulkCategory}
-            onChange={(e) => setBulkCategory(e.target.value)}
-            className="text-xs border rounded px-2 py-1"
+          {/* Period filter */}
+          <Select value={filterPeriodId} onValueChange={(v) => { setFilterPeriodId(v); setPage(1); }}>
+            <SelectTrigger className="w-[180px] bg-white/[0.04] border-white/[0.08] text-white/70">
+              <SelectValue placeholder="All Periods" />
+            </SelectTrigger>
+            <SelectContent className="bg-navy-800 border-white/[0.08] max-h-[300px]">
+              <SelectItem value="all">All Periods</SelectItem>
+              {monthOptions.map((p) => (
+                <SelectItem key={p.period_id} value={p.period_id.toString()}>{p.month}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Spacer */}
+          <div className="flex-1" />
+
+          {/* Export button */}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              const exportData = filtered.map((t) => ({
+                date: t.date,
+                description: t.title,
+                amount: t.amount,
+                type: t.type,
+                category: t.category,
+                paid: t.done,
+                notes: t.notes || '',
+                period: periodIdToMonth.get(t.period_id) || '',
+              }));
+              if (exportData.length === 0) {
+                toast.info('No transactions found');
+                return;
+              }
+              const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = filterPeriodId !== 'all' ? `transactions-${filterPeriodId}.json` : 'transactions-all.json';
+              document.body.appendChild(a);
+              a.click();
+              document.body.removeChild(a);
+              URL.revokeObjectURL(url);
+            }}
+            className="gap-1.5 text-white/50 hover:text-white/80 hover:bg-white/[0.06] h-9"
           >
-            <option value="">Change category...</option>
-            {categories.map((c) => (
-              <option key={c.id} value={c.name}>{c.name}</option>
-            ))}
-          </select>
-          <Button size="sm" variant="outline" onClick={handleBulkCategory} disabled={!bulkCategory}>
-            Apply
+            <Download className="w-3.5 h-3.5" />
+            Export
           </Button>
-          <Button size="sm" variant="destructive" onClick={handleBulkDelete}>
-            Delete
-          </Button>
-        </div>
-      )}
 
-      <div className="overflow-x-auto">
+          {/* Active filter count badge */}
+          {activeFilterCount > 0 && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={clearFilters}
+              className="gap-1.5 text-white/50 hover:text-white/80 hover:bg-white/[0.06] h-9"
+            >
+              <X className="w-3.5 h-3.5" />
+              Clear ({activeFilterCount})
+            </Button>
+          )}
+        </div>
+
+        {/* Advanced filters toggle */}
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setAdvancedOpen(!advancedOpen)}
+            className={`gap-1.5 text-xs h-7 transition-colors ${
+              advancedOpen || hasAdvancedFilters
+                ? 'text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/15'
+                : 'text-white/40 hover:text-white/60 hover:bg-white/[0.04]'
+            }`}
+          >
+            <SlidersHorizontal className="w-3 h-3" />
+            Advanced Filters
+            <ChevronDown className={`w-3 h-3 transition-transform ${advancedOpen ? 'rotate-180' : ''}`} />
+            {hasAdvancedFilters && (
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 ml-1" />
+            )}
+          </Button>
+
+          {hasAdvancedFilters && !advancedOpen && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {dateFrom && (
+                <Badge variant="outline" className="text-[10px] py-0 h-5 gap-1 border-white/[0.08] text-white/50">
+                  From: {dateFrom}
+                  <button onClick={() => setDateFrom('')}><X className="w-2.5 h-2.5" /></button>
+                </Badge>
+              )}
+              {dateTo && (
+                <Badge variant="outline" className="text-[10px] py-0 h-5 gap-1 border-white/[0.08] text-white/50">
+                  To: {dateTo}
+                  <button onClick={() => setDateTo('')}><X className="w-2.5 h-2.5" /></button>
+                </Badge>
+              )}
+              {amountMin && (
+                <Badge variant="outline" className="text-[10px] py-0 h-5 gap-1 border-white/[0.08] text-white/50">
+                  ≥ {formatIdr(parseFloat(amountMin))}
+                  <button onClick={() => setAmountMin('')}><X className="w-2.5 h-2.5" /></button>
+                </Badge>
+              )}
+              {amountMax && (
+                <Badge variant="outline" className="text-[10px] py-0 h-5 gap-1 border-white/[0.08] text-white/50">
+                  ≤ {formatIdr(parseFloat(amountMax))}
+                  <button onClick={() => setAmountMax('')}><X className="w-2.5 h-2.5" /></button>
+                </Badge>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Advanced filters panel */}
+        <AnimatePresence>
+          {advancedOpen && (
+            <motion.div
+              initial={{ height: 0, opacity: 0, marginTop: 0 }}
+              animate={{ height: 'auto', opacity: 1, marginTop: 4 }}
+              exit={{ height: 0, opacity: 0, marginTop: 0 }}
+              transition={{ duration: 0.2 }}
+              className="overflow-hidden"
+            >
+              <div className="glass-card p-4 rounded-xl">
+                <div className="flex flex-col sm:flex-row gap-4">
+                  {/* Date range */}
+                  <div className="flex-1">
+                    <label className="text-[10px] font-medium text-white/30 uppercase tracking-wider mb-2 block">
+                      Date Range
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="date"
+                        value={dateFrom}
+                        onChange={(e) => { setDateFrom(e.target.value); setPage(1); }}
+                        className="flex-1 bg-white/[0.04] border-white/[0.08] text-white/70 text-xs h-8"
+                      />
+                      <span className="text-white/20 text-xs">→</span>
+                      <Input
+                        type="date"
+                        value={dateTo}
+                        onChange={(e) => { setDateTo(e.target.value); setPage(1); }}
+                        className="flex-1 bg-white/[0.04] border-white/[0.08] text-white/70 text-xs h-8"
+                      />
+                    </div>
+                  </div>
+
+                  {/* Amount range */}
+                  <div className="flex-1">
+                    <label className="text-[10px] font-medium text-white/30 uppercase tracking-wider mb-2 block">
+                      Amount Range
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <div className="relative flex-1">
+                        <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-white/20 text-xs">Rp</span>
+                        <Input
+                          type="number"
+                          placeholder="Min"
+                          value={amountMin}
+                          onChange={(e) => { setAmountMin(e.target.value); setPage(1); }}
+                          className="pl-8 bg-white/[0.04] border-white/[0.08] text-white/70 text-xs h-8"
+                        />
+                      </div>
+                      <span className="text-white/20 text-xs">→</span>
+                      <div className="relative flex-1">
+                        <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-white/20 text-xs">Rp</span>
+                        <Input
+                          type="number"
+                          placeholder="Max"
+                          value={amountMax}
+                          onChange={(e) => { setAmountMax(e.target.value); setPage(1); }}
+                          className="pl-8 bg-white/[0.04] border-white/[0.08] text-white/70 text-xs h-8"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Quick presets */}
+                <div className="flex items-center gap-2 mt-3 pt-3 border-t border-white/[0.05]">
+                  <span className="text-[10px] font-medium text-white/25 uppercase tracking-wider">Presets:</span>
+                  {[
+                    { label: 'This Month', dateFrom: new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString().slice(0, 10), dateTo: '' },
+                    { label: 'Last Month', dateFrom: new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1).toISOString().slice(0, 10), dateTo: new Date(new Date().getFullYear(), new Date().getMonth(), 0).toISOString().slice(0, 10) },
+                    { label: 'Last 7d', dateFrom: new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10), dateTo: '' },
+                    { label: 'Last 30d', dateFrom: new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10), dateTo: '' },
+                  ].map((preset) => (
+                    <Button
+                      key={preset.label}
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => { setDateFrom(preset.dateFrom); setDateTo(preset.dateTo); setPage(1); }}
+                      className="h-6 text-[10px] px-2 text-white/40 hover:text-white/70 hover:bg-white/[0.06]"
+                    >
+                      {preset.label}
+                    </Button>
+                  ))}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => { setDateFrom(''); setDateTo(''); setAmountMin(''); setAmountMax(''); setPage(1); }}
+                    className="h-6 text-[10px] px-2 text-white/25 hover:text-white/50 ml-auto"
+                  >
+                    Clear
+                  </Button>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* ─── Summary Bar ────────────────────────────────────────── */}
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-xs text-white/30">
+          <span className="text-white/60 font-semibold">{filtered.length.toLocaleString()}</span> transaction{filtered.length !== 1 ? 's' : ''}
+          {filtered.length !== transactions.length && (
+            <span className="text-white/20"> / {transactions.length.toLocaleString()} total</span>
+          )}
+        </p>
+      </div>
+
+      {/* ─── Bulk Actions ───────────────────────────────────────── */}
+      <AnimatePresence>
+        {selected.size > 0 && (
+          <motion.div
+            initial={{ height: 0, opacity: 0, marginBottom: 0 }}
+            animate={{ height: 'auto', opacity: 1, marginBottom: 16 }}
+            exit={{ height: 0, opacity: 0, marginBottom: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/20">
+              <span className="text-xs font-semibold text-emerald-400">{selected.size} selected</span>
+              <Select value={bulkCategory} onValueChange={setBulkCategory}>
+                <SelectTrigger className="w-[180px] h-8 text-xs bg-white/[0.04] border-white/[0.08] text-white/60">
+                  <SelectValue placeholder="Change category..." />
+                </SelectTrigger>
+                <SelectContent className="bg-navy-800 border-white/[0.08]">
+                  {categories.map((c) => (
+                    <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button size="sm" variant="outline" onClick={handleBulkCategory} disabled={!bulkCategory}
+                className="h-8 text-xs border-white/[0.08] text-white/60 hover:bg-white/[0.06] hover:text-white"
+              >
+                Apply
+              </Button>
+              <div className="flex-1" />
+              <Button size="sm" variant="ghost" onClick={() => setSelected(new Set())}
+                className="h-8 text-xs text-white/40 hover:text-white/70"
+              >
+                Deselect
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleBulkDelete}
+                className="h-8 text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10"
+              >
+                Delete {selected.size}
+              </Button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* ─── Table ───────────────────────────────────────────────── */}
+      <div className="overflow-x-auto rounded-xl border border-white/[0.06]">
         <Table>
           <TableHeader>
-            <TableRow>
-              <TableHead className="w-10">
+            <TableRow className="bg-white/[0.02] border-white/[0.06] hover:bg-white/[0.02]">
+              <TableHead className="w-10 py-3">
                 <Checkbox
                   checked={selected.size === pageRows.length && pageRows.length > 0}
                   onCheckedChange={toggleSelectAll}
                   aria-label="Select all"
                 />
               </TableHead>
-              <SortableHeader sortKey="paid" currentDirection={isSorted('paid')} onSort={toggleSort}>Paid</SortableHeader>
-              {showMonth && <SortableHeader sortKey="month" currentDirection={isSorted('month')} onSort={toggleSort}>Month</SortableHeader>}
-              <SortableHeader sortKey="title" currentDirection={isSorted('title')} onSort={toggleSort}>Title</SortableHeader>
-              <SortableHeader sortKey="category" currentDirection={isSorted('category')} onSort={toggleSort}>Category</SortableHeader>
-              <SortableHeader sortKey="date" currentDirection={isSorted('date')} onSort={toggleSort}>Date</SortableHeader>
-              <SortableHeader sortKey="amount" currentDirection={isSorted('amount')} onSort={toggleSort} className="text-right">Amount</SortableHeader>
-              <SortableHeader sortKey="type" currentDirection={isSorted('type')} onSort={toggleSort}>Type</SortableHeader>
-              <TableHead></TableHead>
+              <SortableHeader sortKey="paid" currentDirection={isSorted('paid')} onSort={toggleSort} className="text-white/40">Paid</SortableHeader>
+              {showMonth && <SortableHeader sortKey="month" currentDirection={isSorted('month')} onSort={toggleSort} className="text-white/40">Month</SortableHeader>}
+              <SortableHeader sortKey="title" currentDirection={isSorted('title')} onSort={toggleSort} className="text-white/40">Title</SortableHeader>
+              <SortableHeader sortKey="category" currentDirection={isSorted('category')} onSort={toggleSort} className="text-white/40">Category</SortableHeader>
+              <SortableHeader sortKey="date" currentDirection={isSorted('date')} onSort={toggleSort} className="text-white/40">Date</SortableHeader>
+              <SortableHeader sortKey="amount" currentDirection={isSorted('amount')} onSort={toggleSort} className="text-right text-white/40">Amount</SortableHeader>
+              <SortableHeader sortKey="type" currentDirection={isSorted('type')} onSort={toggleSort} className="text-white/40">Type</SortableHeader>
+              <TableHead className="text-white/40"></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {pageRows.map((row) => {
-              const createdDate = parseCreatedTime(row);
-              const dateStr = isNaN(createdDate.getTime())
-                ? row.date
-                : createdDate.toLocaleDateString('id-ID', { year: 'numeric', month: 'short', day: 'numeric' });
+            {pageRows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={showMonth ? 9 : 8} className="text-center py-12 text-white/25 text-sm">
+                  <Filter className="w-8 h-8 mx-auto mb-3 opacity-30" />
+                  No transactions found
+                  {activeFilterCount > 0 && (
+                    <div className="mt-1">
+                      <button onClick={clearFilters} className="text-emerald-400 text-xs hover:underline">
+                        Clear all filters
+                      </button>
+                    </div>
+                  )}
+                </TableCell>
+              </TableRow>
+            ) : (
+              pageRows.map((row) => {
+                const createdDate = parseCreatedTime(row);
+                const dateStr = isNaN(createdDate.getTime())
+                  ? row.date
+                  : createdDate.toLocaleDateString('id-ID', { year: 'numeric', month: 'short', day: 'numeric' });
 
-              const typeClass =
-                row.type === 'cash'
-                  ? 'text-blue-600 dark:text-blue-400'
-                  : row.type === 'credit_payment'
-                  ? 'text-amber-600 dark:text-amber-400'
-                  : 'text-purple-600 dark:text-purple-400';
-              const typeLabel =
-                row.type === 'cash' ? 'Cash' : row.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
+                const typeColorClass =
+                  row.type === 'cash'
+                    ? 'text-blue-400'
+                    : row.type === 'credit_payment'
+                    ? 'text-amber-400'
+                    : 'text-purple-400';
+                const typeBgClass =
+                  row.type === 'cash'
+                    ? 'bg-blue-500/10'
+                    : row.type === 'credit_payment'
+                    ? 'bg-amber-500/10'
+                    : 'bg-purple-500/10';
+                const typeLabel =
+                  row.type === 'cash' ? 'Cash' : row.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
 
-              return (
-                <TableRow key={row.id}>
-                  <TableCell>
-                    <Checkbox
-                      checked={selected.has(row.id)}
-                      onCheckedChange={() => toggleSelect(row.id)}
-                      aria-label={`Select ${row.title}`}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={async () => {
-                        await toggleTransactionDoneApi(row.id, !row.done);
-                        window.location.reload();
-                      }}
-                      className={`h-7 text-xs font-semibold px-2 py-0 ${
-                        row.done
-                          ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400'
-                          : 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400'
-                      }`}
-                    >
-                      {row.done ? 'Paid' : 'Unpaid'}
-                    </Button>
-                  </TableCell>
-                  {showMonth && <TableCell className="font-medium">{periodIdToMonth.get(row.period_id) || ''}</TableCell>}
-                  <TableCell>
-                    <span>{row.title}</span>
-                    {row.notes && (
-                      <StickyNote className="inline ml-1.5 align-middle w-3.5 h-3.5 text-amber-500 dark:text-amber-400" title={row.notes} />
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">{row.category}</Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-xs">{dateStr}</TableCell>
-                  <TableCell className="font-medium text-right">{formatIdr(row.amount)}</TableCell>
-                  <TableCell className={`${typeClass} text-xs font-semibold uppercase`}>{typeLabel}</TableCell>
-                  <TableCell>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => {
-                          setEditingId(row.id);
-                          setEditForm({ ...row });
-                        }}
-                        className="h-7 text-xs text-blue-500 hover:text-blue-700"
-                      >
-                        Edit
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
+                return (
+                  <TableRow key={row.id} className="border-white/[0.04] hover:bg-white/[0.02] transition-colors">
+                    <TableCell className="py-2.5">
+                      <Checkbox
+                        checked={selected.has(row.id)}
+                        onCheckedChange={() => toggleSelect(row.id)}
+                        aria-label={`Select ${row.title}`}
+                      />
+                    </TableCell>
+                    <TableCell className="py-2.5">
+                      <button
                         onClick={async () => {
-                          const confirmed = await confirmAction({
-                            title: 'Delete Transaction',
-                            description: `Delete "${row.title}" (${formatIdr(row.amount)})?`,
-                            confirmLabel: 'Delete',
-                            variant: 'destructive',
-                          });
-                          if (!confirmed) return;
-                          await deleteTransactionApi(row.id);
+                          await toggleTransactionDoneApi(row.id, !row.done);
                           window.location.reload();
                         }}
-                        className="h-7 text-xs text-red-500 hover:text-red-700"
+                        className={`h-6 text-[10px] font-semibold px-2 rounded-md transition-colors ${
+                          row.done
+                            ? 'bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25'
+                            : 'bg-red-500/10 text-red-400 hover:bg-red-500/20'
+                        }`}
                       >
-                        Delete
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
+                        {row.done ? 'Paid' : 'Unpaid'}
+                      </button>
+                    </TableCell>
+                    {showMonth && <TableCell className="py-2.5 text-white/60 text-sm">{periodIdToMonth.get(row.period_id) || ''}</TableCell>}
+                    <TableCell className="py-2.5">
+                      <span className="text-white/80">{row.title}</span>
+                      {row.notes && (
+                        <StickyNote className="inline ml-1.5 align-middle w-3 h-3 text-amber-400 shrink-0" title={row.notes} />
+                      )}
+                    </TableCell>
+                    <TableCell className="py-2.5">
+                      <Badge variant="secondary" className="text-[10px] bg-white/[0.06] text-white/60 border-white/[0.06] font-normal">
+                        {row.category}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="py-2.5 text-white/40 text-xs whitespace-nowrap">{dateStr}</TableCell>
+                    <TableCell className="py-2.5 font-semibold text-right text-white/80 tabular-nums whitespace-nowrap">{formatIdr(row.amount)}</TableCell>
+                    <TableCell className="py-2.5">
+                      <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase ${typeColorClass} ${typeBgClass}`}>
+                        {typeLabel}
+                      </span>
+                    </TableCell>
+                    <TableCell className="py-2.5">
+                      <div className="flex gap-1">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => { setEditingId(row.id); setEditForm({ ...row }); }}
+                          className="h-7 text-xs text-white/50 hover:text-white hover:bg-white/[0.06]"
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={async () => {
+                            const confirmed = await confirmAction({
+                              title: 'Delete Transaction',
+                              description: `Delete "${row.title}" (${formatIdr(row.amount)})?`,
+                              confirmLabel: 'Delete',
+                              variant: 'destructive',
+                            });
+                            if (!confirmed) return;
+                            await deleteTransactionApi(row.id);
+                            window.location.reload();
+                          }}
+                          className="h-7 text-xs text-white/30 hover:text-red-400 hover:bg-red-500/10"
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
           </TableBody>
         </Table>
       </div>
 
+      {/* ─── Pagination ─────────────────────────────────────────── */}
       <div className="flex items-center justify-between mt-4">
-        <p className="text-xs text-white/50">
-          Showing {(safePage - 1) * rowsPerPage + 1}–{Math.min(safePage * rowsPerPage, filtered.length)} of {filtered.length}
+        <p className="text-xs text-white/30">
+          {filtered.length > 0
+            ? `Showing ${(safePage - 1) * rowsPerPage + 1}–${Math.min(safePage * rowsPerPage, filtered.length)} of ${filtered.length}`
+            : 'No results'}
         </p>
         <div className="flex items-center gap-2">
           <Button
             size="sm"
             variant="outline"
+            onClick={() => setPage(1)}
+            disabled={safePage <= 1}
+            className="h-7 text-xs border-white/[0.08] text-white/40 hover:bg-white/[0.06] disabled:opacity-20"
+          >
+            First
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={safePage <= 1}
+            className="h-7 text-xs border-white/[0.08] text-white/40 hover:bg-white/[0.06] disabled:opacity-20"
           >
-            Previous
+            Prev
           </Button>
-          <span className="text-xs text-white/50 min-w-[3rem] text-center">
-            {safePage} / {totalPages}
+          <span className="text-xs text-white/40 min-w-[5rem] text-center tabular-nums">
+            {safePage} <span className="text-white/15">/</span> {totalPages}
           </span>
           <Button
             size="sm"
             variant="outline"
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={safePage >= totalPages}
+            className="h-7 text-xs border-white/[0.08] text-white/40 hover:bg-white/[0.06] disabled:opacity-20"
           >
             Next
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setPage(totalPages)}
+            disabled={safePage >= totalPages}
+            className="h-7 text-xs border-white/[0.08] text-white/40 hover:bg-white/[0.06] disabled:opacity-20"
+          >
+            Last
           </Button>
         </div>
       </div>
 
+      {/* ─── Edit Dialog ────────────────────────────────────────── */}
       {editingId && (
         <EditTransactionDialog
           open={true}

--- a/src/components/WeeklyTracker.tsx
+++ b/src/components/WeeklyTracker.tsx
@@ -16,7 +16,6 @@ import { Bar, Doughnut, Line } from 'react-chartjs-2';
 import type { MonthlySummary } from '../lib/data';
 import { formatIdr, formatNumber } from '../lib/utils';
 import { fetchSummaries } from '../lib/api';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -399,14 +398,14 @@ export default function WeeklyTracker() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card>
-          <CardContent className="p-4">
+        <div className="glass-card p-5">
+          
             <p className="text-xs text-white/50 font-medium">Income</p>
             <p className="text-lg font-bold">{formatIdr(weeklyData.income)}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-xs text-white/50 font-medium">Total Spent</p>
             <p className="text-lg font-bold">{formatIdr(weeklyData.totalSpend)}</p>
             {weeklyData.income > 0 && (
@@ -416,17 +415,17 @@ export default function WeeklyTracker() {
                   : `${Math.round(((weeklyData.totalSpend - weeklyData.income) / weeklyData.income) * 100)}% over`}
               </p>
             )}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-xs text-white/50 font-medium">Weekly Budget</p>
             <p className="text-lg font-bold">{formatIdr(weeklyData.weeklyBudget)}</p>
             <p className="text-xs text-white/40 mt-1">{weeklyData.weeks.length} weeks in period</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
+          
+        </div>
+        <div className="glass-card p-5">
+          
             <p className="text-xs text-white/50 font-medium">Avg Daily Spend</p>
             <p className="text-lg font-bold">
               {formatIdr(
@@ -434,20 +433,20 @@ export default function WeeklyTracker() {
               )}
             </p>
             <p className="text-xs text-white/40 mt-1">{weeklyData.totalTxCount} transactions</p>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Insights */}
       {insights.length > 0 && (
-        <Card className="border-indigo-200 dark:border-indigo-800/50 bg-indigo-50/50 dark:bg-indigo-950/20">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
+        <div className="glass-card p-5 border-indigo-200 dark:border-indigo-800/50 bg-indigo-50/50 dark:bg-indigo-950/20">
+          
+            <h3 className="text-sm font-medium flex items-center gap-2 text-white/80">
               <Target className="w-4 h-4 text-indigo-500" />
               Weekly Insights
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
+            </h3>
+          
+          
             <ul className="space-y-2">
               {insights.map((ins, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm">
@@ -458,32 +457,32 @@ export default function WeeklyTracker() {
                 </li>
               ))}
             </ul>
-          </CardContent>
-        </Card>
+          
+        </div>
       )}
 
       {/* Main Chart: Weekly Spending vs Budget */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Weekly Spending vs Budget</CardTitle>
-          <CardDescription>Each bar represents total spending for that week. The dashed line is your weekly budget target.</CardDescription>
-        </CardHeader>
-        <CardContent>
+      <div className="glass-card p-5">
+        
+          <h3 className="text-base text-white/80">Weekly Spending vs Budget</h3>
+          <p className="text-white/50">Each bar represents total spending for that week. The dashed line is your weekly budget target.</p>
+        
+        
           <div style={{ height: 300 }}>
             <Bar data={barChartData} options={chartOptions} />
           </div>
-        </CardContent>
-      </Card>
+        
+      </div>
 
       {/* Row: Weekly cards + Average daily trend */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Weekly Breakdown Cards */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Week-by-Week Breakdown</CardTitle>
-            <CardDescription>Click a week to see its category breakdown.</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base text-white/80">Week-by-Week Breakdown</h3>
+            <p className="text-white/50">Click a week to see its category breakdown.</p>
+          
+          
             <div className="space-y-3">
               {weeklyData.weeks.map((w, idx) => {
                 const isOver = w.total > weeklyData.weeklyBudget;
@@ -564,16 +563,16 @@ export default function WeeklyTracker() {
                 );
               })}
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Average Daily Spend Trend */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Average Daily Spend Trend</CardTitle>
-            <CardDescription>How your daily spending pace shifts across the period.</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base text-white/80">Average Daily Spend Trend</h3>
+            <p className="text-white/50">How your daily spending pace shifts across the period.</p>
+          
+          
             <div style={{ height: 300 }}>
               <Line data={trendData} options={lineOptions} />
             </div>
@@ -600,19 +599,19 @@ export default function WeeklyTracker() {
                 );
               })}
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
 
       {/* Row: Category donut + Full table */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Category Distribution Donut */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Category Distribution</CardTitle>
-            <CardDescription>Where your money goes across the whole period.</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5">
+          
+            <h3 className="text-base text-white/80">Category Distribution</h3>
+            <p className="text-white/50">Where your money goes across the whole period.</p>
+          
+          
             <div className="max-w-[250px] mx-auto" style={{ height: 250 }}>
               <Doughnut
                 data={categoryDonutData}
@@ -634,16 +633,16 @@ export default function WeeklyTracker() {
                 }}
               />
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
 
         {/* Full Category × Week Table */}
-        <Card className="lg:col-span-2">
-          <CardHeader>
-            <CardTitle className="text-base">Category × Week Matrix</CardTitle>
-            <CardDescription>Spending per category across each week of the period.</CardDescription>
-          </CardHeader>
-          <CardContent>
+        <div className="glass-card p-5 lg:col-span-2">
+          
+            <h3 className="text-base text-white/80">Category × Week Matrix</h3>
+            <p className="text-white/50">Spending per category across each week of the period.</p>
+          
+          
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
@@ -692,8 +691,8 @@ export default function WeeklyTracker() {
                 </TableBody>
               </Table>
             </div>
-          </CardContent>
-        </Card>
+          
+        </div>
       </div>
     </div>
   );

--- a/src/components/WhatIfPlanner.tsx
+++ b/src/components/WhatIfPlanner.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { formatIdr, formatNumber } from '../lib/utils';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -241,11 +234,9 @@ export default function WhatIfPlanner() {
 
   if (error || !data || !projection) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-destructive">Error loading data: {error || 'Unknown error'}</p>
-        </CardContent>
-      </Card>
+      <div className="glass-card p-5">
+        <p className="text-destructive">Error loading data: {error || 'Unknown error'}</p>
+        </div>
     );
   }
 
@@ -354,61 +345,52 @@ export default function WhatIfPlanner() {
     <div className="space-y-6">
       {/* ─── Summary KPI cards ─────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <Card>
-          <CardContent className="pt-4 pb-4 px-4">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Projected Net Worth</p>
+        <div className="glass-card p-5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Projected Net Worth</p>
             <p className={`text-xl font-bold mt-1 ${projection.networthDifference >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
               {formatIdr(projection.finalScenario)}
             </p>
             <p className="text-[11px] mt-1 text-muted-foreground">
               {projection.networthDifference >= 0 ? '▲' : '▼'} {formatIdr(Math.abs(projection.networthDifference))} vs baseline
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-4 px-4">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Monthly Savings</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Monthly Savings</p>
             <p className={`text-xl font-bold mt-1 ${projection.monthlyNet >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
               {formatIdr(projection.monthlyNet)}
             </p>
             <p className="text-[11px] mt-1 text-muted-foreground">
               vs {formatIdr(data.avgSavings)} baseline
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-4 px-4">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Savings Rate</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Savings Rate</p>
             <p className={`text-xl font-bold mt-1 ${projection.adjustedIncome > 0 && projection.monthlyNet / projection.adjustedIncome >= 0.2 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}>
               {projection.adjustedIncome > 0 ? ((projection.monthlyNet / projection.adjustedIncome) * 100).toFixed(1) : '0'}%
             </p>
             <p className="text-[11px] mt-1 text-muted-foreground">
               vs {data.savingsRate.toFixed(1)}% baseline
             </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4 pb-4 px-4">
-            <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Total Saved ({projectionMonths}mo)</p>
+          </div>
+        <div className="glass-card p-5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Total Saved ({projectionMonths}mo)</p>
             <p className={`text-xl font-bold mt-1 ${projection.totalSaved >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
               {formatIdr(projection.totalSaved)}
             </p>
             <p className="text-[11px] mt-1 text-muted-foreground">
               vs {formatIdr(projection.baselineTotalSaved)} baseline
             </p>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ─── Net Worth Projection Chart ────────────────────────────────────── */}
-      <Card>
-        <CardHeader className="pb-2">
-          <div className="flex items-center justify-between flex-wrap gap-2">
+      <div className="glass-card p-5">
+        <div className="flex items-center justify-between flex-wrap gap-2">
             <div>
-              <CardTitle className="text-lg">Net Worth Projection</CardTitle>
-              <CardDescription className="text-xs">
+              <h3 className="text-lg text-white/80">Net Worth Projection</h3>
+              <p className="text-xs text-white/50">
                 Baseline trend vs your what-if scenario over {projectionMonths} months
-              </CardDescription>
+              </p>
             </div>
             <div className="flex gap-1">
               {([6, 12, 24] as ProjectionMonths[]).map((m) => (
@@ -424,43 +406,33 @@ export default function WhatIfPlanner() {
               ))}
             </div>
           </div>
-        </CardHeader>
-        <CardContent>
-          <div style={{ height: 320 }}>
+        <div style={{ height: 320 }}>
             <Line data={networthChartData} options={networthChartOptions} />
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ─── Cashflow Comparison ───────────────────────────────────────────── */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-lg">Monthly Cashflow: Baseline vs Scenario</CardTitle>
-          <CardDescription className="text-xs">
+      <div className="glass-card p-5">
+        <h3 className="text-lg text-white/80">Monthly Cashflow: Baseline vs Scenario</h3>
+          <p className="text-xs text-white/50">
             How income, spending, and savings change with your adjustments
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div style={{ height: 240 }}>
+          </p>
+        <div style={{ height: 240 }}>
             <Bar data={cashflowData} options={cashflowOptions} />
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ─── Controls ──────────────────────────────────────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Income Control */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
+        <div className="glass-card p-5">
+          <h3 className="text-base flex items-center gap-2 text-white/80">
               💰 Income Adjustment
-            </CardTitle>
-            <CardDescription className="text-xs">
+            </h3>
+            <p className="text-xs text-white/50">
               Simulate a raise, bonus, or income loss
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
+            </p>
+          <div>
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm font-medium">Income Change</span>
                 <Badge variant={incomeChangePct >= 0 ? 'default' : 'destructive'} className="text-xs">
@@ -494,28 +466,24 @@ export default function WhatIfPlanner() {
                 </p>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
         {/* One-Time Events */}
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
+        <div className="glass-card p-5">
+          <div className="flex items-center justify-between">
               <div>
-                <CardTitle className="text-base flex items-center gap-2">
+                <h3 className="text-base flex items-center gap-2 text-white/80">
                   🎯 One-Time Events
-                </CardTitle>
-                <CardDescription className="text-xs">
+                </h3>
+                <p className="text-xs text-white/50">
                   Bonuses, large purchases, or unexpected costs
-                </CardDescription>
+                </p>
               </div>
               <Button size="sm" variant="outline" onClick={addOneTimeEvent} className="h-8 text-xs">
                 + Add Event
               </Button>
             </div>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {oneTimeEvents.length === 0 ? (
+          {oneTimeEvents.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-6">
                 No one-time events. Add a bonus, tax refund, or large purchase.
               </p>
@@ -559,21 +527,19 @@ export default function WhatIfPlanner() {
             <p className="text-[10px] text-muted-foreground">
               💡 Use negative amounts for expenses, positive for income.
             </p>
-          </CardContent>
-        </Card>
+          </div>
       </div>
 
       {/* ─── Category Spending Adjustments ─────────────────────────────────── */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between flex-wrap gap-2">
+      <div className="glass-card p-5">
+        <div className="flex items-center justify-between flex-wrap gap-2">
             <div>
-              <CardTitle className="text-base flex items-center gap-2">
+              <h3 className="text-base flex items-center gap-2 text-white/80">
                 🛒 Category Spending Adjustments
-              </CardTitle>
-              <CardDescription className="text-xs">
+              </h3>
+              <p className="text-xs text-white/50">
                 Drag sliders to simulate cutting or increasing spending per category
-              </CardDescription>
+              </p>
             </div>
             <div className="flex items-center gap-2">
               {Object.keys(categoryAdjustments).length > 0 && (
@@ -586,9 +552,7 @@ export default function WhatIfPlanner() {
               </Button>
             </div>
           </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {visibleCategories.map((cat) => {
+        {visibleCategories.map((cat) => {
             const adj = categoryAdjustments[cat.name];
             const pct = adj?.pct ?? 0;
             const newAmount = cat.avg_spending + (adj?.delta ?? 0);
@@ -619,14 +583,12 @@ export default function WhatIfPlanner() {
               </div>
             );
           })}
-        </CardContent>
-      </Card>
+        </div>
 
       {/* ─── Reset & Insight Bar ───────────────────────────────────────────── */}
       {(incomeChangePct !== 0 || Object.keys(categoryAdjustments).length > 0 || oneTimeEvents.length > 0) && (
-        <Card className={`border-l-4 ${projection.networthDifference >= 0 ? 'border-l-emerald-500' : 'border-l-amber-500'}`}>
-          <CardContent className="py-4 flex items-center justify-between flex-wrap gap-3">
-            <div className="flex-1 min-w-0">
+        <div className={`glass-card p-5 border-l-4 ${projection.networthDifference >= 0 ? 'border-l-emerald-500' : 'border-l-amber-500'}`}>
+          <div className="flex-1 min-w-0">
               <p className="text-sm font-medium">
                 {projection.networthDifference >= 0 ? '✅' : '⚠️'}{' '}
                 {projection.networthDifference >= 0
@@ -640,8 +602,7 @@ export default function WhatIfPlanner() {
             <Button size="sm" variant="outline" onClick={resetScenario} className="flex-shrink-0">
               ↺ Reset All
             </Button>
-          </CardContent>
-        </Card>
+          </div>
       )}
     </div>
   );

--- a/src/components/YearlyReport.tsx
+++ b/src/components/YearlyReport.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import type { MonthlySummary, Category } from '../lib/data';
 import { formatIdr } from '../lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -249,18 +248,15 @@ export default function YearlyReport({ summaries, categories }: Props) {
       </div>
 
       {yearSummaries.length === 0 ? (
-        <Card>
-          <CardContent className="py-12 text-center text-muted-foreground">
-            No data available for {selectedYear}.
-          </CardContent>
-        </Card>
+        <div className="glass-card p-5">
+          No data available for {selectedYear}.
+          </div>
       ) : (
         <>
           {/* Summary Cards */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/30">
                     <Wallet className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
                   </div>
@@ -270,11 +266,9 @@ export default function YearlyReport({ summaries, categories }: Props) {
                     <DeltaBadge current={totals.income} previous={prevTotals.income} />
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30">
                     <Receipt className="w-5 h-5 text-red-600 dark:text-red-400" />
                   </div>
@@ -284,11 +278,9 @@ export default function YearlyReport({ summaries, categories }: Props) {
                     <span className="text-xs text-muted-foreground">vs {formatIdr(prevTotals.spending)} last year</span>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className={`p-2 rounded-lg ${totals.savings >= 0 ? 'bg-emerald-100 dark:bg-emerald-900/30' : 'bg-red-100 dark:bg-red-900/30'}`}>
                     <PiggyBank className={`w-5 h-5 ${totals.savings >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`} />
                   </div>
@@ -300,11 +292,9 @@ export default function YearlyReport({ summaries, categories }: Props) {
                     <DeltaBadge current={totals.savings} previous={prevTotals.savings} />
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
+              </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3">
                   <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
                     <TrendingUp className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                   </div>
@@ -316,45 +306,33 @@ export default function YearlyReport({ summaries, categories }: Props) {
                     </span>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+              </div>
           </div>
 
           {/* Monthly Trend Chart */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <div className="glass-card p-5">
+            <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
                 <CalendarDays className="w-4 h-4 text-white/50" />
                 Monthly Breakdown — {selectedYear}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="relative h-80">
+              </h3>
+            <div className="relative h-80">
                 <Bar data={barChartData} options={barOptions} />
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Category + Highlights Row */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base font-semibold">Top Spending Categories</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="relative h-72">
+            <div className="glass-card p-5">
+              <h3 className="text-base font-semibold text-white/80">Top Spending Categories</h3>
+              <div className="relative h-72">
                   <Doughnut data={doughnutData} options={doughnutOptions} />
                 </div>
-              </CardContent>
-            </Card>
+              </div>
 
             <div className="space-y-6">
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base font-semibold">Top Spending Months</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
+              <div className="glass-card p-5">
+                <h3 className="text-base font-semibold text-white/80">Top Spending Months</h3>
+                <div className="space-y-2">
                     {topSpendingMonths.map((m, i) => (
                       <div key={m.month} className="flex justify-between items-center p-2 rounded-lg bg-slate-50 bg-white/[0.06]">
                         <div className="flex items-center gap-2">
@@ -368,15 +346,11 @@ export default function YearlyReport({ summaries, categories }: Props) {
                       <p className="text-sm text-muted-foreground text-center py-4">No data</p>
                     )}
                   </div>
-                </CardContent>
-              </Card>
+                </div>
 
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base font-semibold">Top Savings Months</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
+              <div className="glass-card p-5">
+                <h3 className="text-base font-semibold text-white/80">Top Savings Months</h3>
+                <div className="space-y-2">
                     {topSavingsMonths.map((m, i) => (
                       <div key={m.month} className="flex justify-between items-center p-2 rounded-lg bg-slate-50 bg-white/[0.06]">
                         <div className="flex items-center gap-2">
@@ -392,18 +366,14 @@ export default function YearlyReport({ summaries, categories }: Props) {
                       <p className="text-sm text-muted-foreground text-center py-4">No data</p>
                     )}
                   </div>
-                </CardContent>
-              </Card>
+                </div>
             </div>
           </div>
 
           {/* Spending Composition */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base font-semibold">Spending Composition</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="glass-card p-5">
+            <h3 className="text-base font-semibold text-white/80">Spending Composition</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="p-4 rounded-lg border bg-white/[0.03]">
                   <p className="text-xs text-muted-foreground mb-1">Cash Expenses</p>
                   <p className="text-xl font-semibold">{formatIdr(totals.cash)}</p>
@@ -426,17 +396,13 @@ export default function YearlyReport({ summaries, categories }: Props) {
                   </p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
 
           {/* Year-over-Year Table */}
           {allYearsStats.length > 1 && (
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base font-semibold">Year-over-Year Comparison</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="rounded-xl border overflow-hidden">
+            <div className="glass-card p-5">
+              <h3 className="text-base font-semibold text-white/80">Year-over-Year Comparison</h3>
+              <div className="rounded-xl border overflow-hidden">
                   <Table>
                     <TableHeader>
                       <TableRow>
@@ -483,8 +449,7 @@ export default function YearlyReport({ summaries, categories }: Props) {
                     </TableBody>
                   </Table>
                 </div>
-              </CardContent>
-            </Card>
+              </div>
           )}
         </>
       )}


### PR DESCRIPTION
Calendar grid now shows 21st of previous month to 20th of selected month instead of standard calendar month.

Changes:
- Grid renders dates 21 (prev month) → 20 (selected month)
- Transaction filtering by period_id with fallback to 21–20 date range
- Month boundary labels (Jan/Feb) on 1st and 21st
- Default selection: latest period
- Header label: "Jul 21 – Aug 20" format