### PR TITLE
Impeccable: critique, polish & bolder — palette cleanup, remove AI UI tells, type hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ vite.config.ts.timestamp-*
 # Documentation
 /docs
 data/financial.db.bak.20260709130426
+.agents/
+.gemini/
+skills-lock.json

--- a/.impeccable/critique/2026-07-28T01-42-07Z__src-components-dashboard-tsx.md
+++ b/.impeccable/critique/2026-07-28T01-42-07Z__src-components-dashboard-tsx.md
@@ -1,0 +1,147 @@
+---
+target: src/components/Dashboard.tsx
+total_score: 22
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+p2_count: 2
+timestamp: 2026-07-28T01-42-07Z
+slug: src-components-dashboard-tsx
+---
+# Design Critique: Financial Dashboard (Dashboard.tsx)
+
+**Method: dual-agent (A: design-review · B: detector+browser)**
+**Target: `src/components/Dashboard.tsx`** · Slug: `src-components-dashboard-tsx`
+
+---
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Good feedback — paid toggles, toast notifications, spending pulse gauge. No global loading bar on navigation. |
+| 2 | Match System / Real World | 3 | Uses familiar finance terminology. "Credit Payment (Prior Month)" is clear. Mix of EN/ID labels (Tagihan, Istri) is intentional for user. |
+| 3 | User Control and Freedom | 2 | No undo on delete (only confirm dialog). Cannot dismiss/collapse individual dashboard sections independently. No way to go back from an accidental filter change except re-selecting. |
+| 4 | Consistency and Standards | 2 | Off-palette colors: purple-400, indigo-600, violet-500, cyan-400, amber-400 used ad-hoc across components. Dashboard itself mixes Tailwind default colors (purple, cyan, amber) with custom navy/mint/coral/gold palette. |
+| 5 | Error Prevention | 2 | Delete has confirm dialog. No duplicate entry detection on add. No validation on amount input beyond required field. Credit card payment auto-generation has no override. |
+| 6 | Recognition Rather Than Recall | 3 | Icons are labeled. Sidebar nav items have text. Bottom tabs have labels. Good discoverability. |
+| 7 | Flexibility and Efficiency of Use | 2 | Shift+N shortcut for quick add exists. No keyboard nav for transaction table. No saved filter presets. No bulk edit on dashboard table. |
+| 8 | Aesthetic and Minimalist Design | 2 | Dashboard has 6 sections (PULSE, FLOW, ACT, INSIGHTS, FEED, CHARTS) on one page — high density. Many sections compete for attention. 6 charts at the bottom is cluttered. Section eyebrows (PULSE/FLOW/ACT/etc) at text-white/20 are barely visible. |
+| 9 | Error Recovery | 2 | Toast notifications show success. Error states show generic messages. No retry on API failure. Form errors not shown inline. |
+| 10 | Help and Documentation | 1 | No contextual help, tooltips, or onboarding. First-time users see dense dashboard with no guidance. No FAQ or help page. |
+| **Total** | | **22/40** | **Acceptable — significant improvements needed** |
+
+---
+
+## Design Specificity Verdict
+
+**LLM Assessment**: The dashboard has a distinctive visual identity — the dark navy glass-morphism aesthetic with mint accent is grounded and intentional. However, the specificity falls apart in secondary screens where AI-generated tells proliferate: violet/purple gradients (SpendingStreaks, SpendingDna, Achievements), indigo text colors (BudgetRecommendations, CategoryMatrix), and side-tab accent borders (RecurringCostAnalyzer, WhatIfPlanner, BudgetAlerts). These are textbook AI-UI patterns that undermine the otherwise custom navy/mint system.
+
+The primary dashboard (Dashboard.tsx) itself has off-palette leaks: `text-purple-400` for credit expenses, `text-cyan-400` for cash type labels, `bg-purple-500` for progress bars — none of which belong to the defined navy/mint/coral/gold palette in tailwind.config.mjs.
+
+**Deterministic scan**: 29 findings across 16 files.
+- 14x `ai-color-palette`: purple/violet/indigo/fuchsia colors detected in 8 components
+- 8x `border-accent-on-rounded`: border + rounded combination creating ghost cards in 6 components
+- 6x `side-tab`: `border-l-4` accent on cards in 4 components
+- 1x `flat-type-hierarchy`: Layout.astro uses only 12px/14px/18px (ratio 1.5:1)
+
+---
+
+## Overall Impression
+
+The FinDash dashboard has a strong foundation: the glass-morphism navy aesthetic, mint accent system, and well-structured data hierarchy show real craft. But the single-page dashboard is overloaded with 6 dense sections, secondary pages are riddled with AI-generated color tells that break the design system, and the typography hierarchy is too flat to guide attention. The biggest opportunity is **consolidation and palette discipline** — fixing off-palette colors and establishing a proper type scale would transform this from "good fintech dashboard" to "distinctly FinDash."
+
+---
+
+## What's Working
+
+1. **Glass-morphism card system**: The `glass-card` / `glass-card-elevated` pattern with `backdrop-blur-xl` and `border border-white/[0.08]` creates a cohesive, premium fintech feel. Consistent across the primary dashboard.
+
+2. **Spending Pulse gauge**: The SVG pace gauge with "Over Pace" indicator is product-specific, visually distinctive, and communicates complex data (spend vs time vs budget) in one compelling visualization.
+
+3. **Salary period system**: The 21st→20th cycle convention is deeply integrated — kickoff flow, period filtering, recurring auto-generation. This is not a generic finance app; it matches a specific real-world payroll cycle.
+
+---
+
+## Priority Issues
+
+### [P1] Off-palette colors break the design system across 8+ components
+**Why it matters**: The defined palette is navy/mint/coral/gold. But purple, violet, indigo, fuchsia, and cyan appear throughout secondary pages, creating visual inconsistency and AI-generated UI tells. Users moving from dashboard to /streaks or /analytics see a different color world.
+**Fix**: Replace all purple/violet/indigo/fuchsia with palette-aligned equivalents:
+- `text-purple-400` → `text-coral-400` or `text-mint-400` (context-dependent)
+- `text-indigo-*` → `text-mint-500` or `text-navy-300`
+- `text-violet-*` → `text-gold-400` or `text-mint-500`
+- `text-cyan-400` → `text-mint-400`
+- `bg-gradient violet/purple/fuchsia` → navy/mint gradients
+- `text-amber-400` → `text-gold-400`
+**Suggested command**: `polish`
+
+### [P1] Side-tab accent borders (border-l-4) on rounded cards — AI UI tell
+**Why it matters**: The detector flagged 6 instances of `border-l-4` on glass cards. This is a textbook AI-generated UI pattern. The project's own glass-card component doesn't use side borders — these are ad-hoc additions in RecurringCostAnalyzer, WhatIfPlanner, BudgetAlerts, BudgetReport.
+**Fix**: Remove `border-l-4` and `border-l-{color}-500` classes. Replace with a subtle full border, a left-positioned icon with color, or a small colored dot indicator.
+**Suggested command**: `polish`
+
+### [P1] Flat typography hierarchy — only 3 sizes across the layout
+**Why it matters**: The detector found only 12px, 14px, and 18px used in Layout.astro (ratio 1.5:1). A proper hierarchy needs at least 4-5 steps with a 1.25+ ratio between each. The dashboard has good large numbers (text-4xl) but the surrounding hierarchy is flat — section headings, card titles, and body text are too similar in size.
+**Fix**: Establish a type scale: 12px (label) → 14px (body) → 16px (card title) → 20px (section heading) → 30px/36px (display). Apply consistently.
+**Suggested command**: `typeset`
+
+### [P2] Dashboard information overload — 6 sections on one page
+**Why it matters**: PULSE (summary + gauge), FLOW (categories + budgets + credit), ACT (add/kickoff), INSIGHTS (net worth + runway + insights), FEED (transaction table), CHARTS (6 charts). Cognitive load checklist fails: single focus (no — multiple competing sections), chunking (partially — sections exist but all visible), minimal choices (no — user sees 20+ data points at once).
+**Fix**: Make CHARTS collapsible by default (show 2, expand for more). Move INSIGHTS section below FEED or into a sidebar. Make the SpendingPulse the clear hero element at the top.
+**Suggested command**: `distill`
+
+### [P2] Uppercase section eyebrows at text-white/20 are nearly invisible
+**Why it matters**: PULSE, FLOW, ACT, INSIGHTS, FEED, CHARTS labels use `text-xs uppercase tracking-wider text-white/20` — that's 20% opacity white on a dark navy background, which fails WCAG contrast requirements. They're decorative noise rather than functional navigation.
+**Fix**: Increase to `text-white/40` minimum for contrast, or replace with a more prominent section divider (e.g., `text-mint-400/60` with a small icon).
+**Suggested command**: `polish`
+
+---
+
+## Persona Red Flags
+
+**Alex (Power User)**:
+- Transaction table on dashboard is limited to 10 rows with no quick filter or search — must navigate to /transactions for any real filtering.
+- No keyboard navigation in the table (arrow keys, enter to edit).
+- Cannot customize which sections appear on the dashboard or re-order them.
+- Month kickoff button ("Start September 2026") is prominent but has no undo if triggered accidentally.
+
+**Casey (Distracted Mobile User)**:
+- Dashboard is extremely long on mobile — 6 sections require significant scrolling.
+- The Spending Pulse gauge section is tall and pushes the actual transaction data far down.
+- Bottom tab bar has 4 tabs + center FAB, but "Analytics" and "Planning" are vague — no indication of what's inside.
+- No lazy loading — all charts render on page load, potentially slow on 3G.
+- Touch targets for table row edit/delete buttons may be too small (icon-only buttons in a tight row).
+
+---
+
+## Minor Observations
+
+- Loading spinners use different colors per component: `border-indigo-500`, `border-blue-600`, `border-emerald-500`, `border-mint-500/40`, `border-slate-600` — should be standardized.
+- `text-amber-400` is used in Dashboard.tsx for credit payments but `gold-400` is the palette equivalent.
+- The `purple-400` used for credit expenses in Dashboard.tsx Credit Snapshot has no corresponding palette token.
+- RecurringCostAnalyzer uses 4 different `border-l-4 border-l-{color}` variants (blue, emerald, amber, violet) as category indicators — these are all off-palette and use the AI side-tab pattern.
+- "Financial Dashboard · Built with Astro & React" footer is developer-facing copy, not user-facing.
+
+---
+
+## Questions to Consider
+
+- Should the dashboard split into tabs (Overview / Feed / Charts) rather than one long scroll?
+- Would a command palette (Cmd+K) for navigation reduce the need for the overloaded sidebar?
+- What if credit expenses used the gold accent instead of purple — tying them to the existing "credit payment = amber/gold" visual language?
+- Does the dashboard need a dark-mode-only approach, or is the light theme actively used?
+
+---
+
+## Run Notes
+
+- Target slug: `src-components-dashboard-tsx` ✓
+- Ignore list: none (.impeccable/critique/ignore.md not found)
+- Assessment independence: dual-agent (A and B ran as isolated sub-agents)
+- CLI detector: ran successfully, 29 findings across 16 files
+- Browser visualization: login + dashboard snapshot captured. Vision analysis unavailable (provider limitation). DOM snapshot used as fallback.
+- Overlay injection: not performed (no mutable browser injection available)
+- Live server: not needed (app already running on :4321)
+- Temp-file cleanup: pending after persistence

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -212,7 +212,7 @@ export default function Achievements({ data }: Props) {
   return (
     <div className="space-y-6">
       {/* ── Hero: Level & Rank ─────────────────────────────────────────── */}
-      <div className="glass-card p-5 overflow-hidden border-0 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white">
+      <div className="glass-card p-5 overflow-hidden border-0 bg-gradient-to-r from-mint-500 to-cyan-600 text-white">
         
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
             <div className="flex items-center gap-5">
@@ -221,7 +221,7 @@ export default function Achievements({ data }: Props) {
                 <div className="w-20 h-20 rounded-full bg-white/20 backdrop-blur-sm border-2 border-white/40 flex items-center justify-center">
                   <Award className="w-9 h-9" />
                 </div>
-                <div className="absolute -bottom-1 -right-1 bg-white text-indigo-600 rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm shadow-lg">
+                <div className="absolute -bottom-1 -right-1 bg-white text-mint-600 rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm shadow-lg">
                   {data.levelInfo.level}
                 </div>
               </div>
@@ -265,11 +265,11 @@ export default function Achievements({ data }: Props) {
 
       {/* ── Next Milestone banner ──────────────────────────────────────── */}
       {data.nextMilestone && (
-        <div className="glass-card p-5 border-dashed border-2 border-indigo-300 dark:border-indigo-700">
-          
+        <div className="glass-card p-5 border-dashed border-2 border-mint-400/30">
+
             <div className="text-3xl">{data.nextMilestone.icon}</div>
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 text-xs text-indigo-600 dark:text-indigo-400 font-medium uppercase tracking-wide">
+              <div className="flex items-center gap-2 text-xs text-mint-500 dark:text-mint-400 font-medium uppercase tracking-wide">
                 <Target className="w-3 h-3" />
                 <span>Next Milestone</span>
               </div>
@@ -278,7 +278,7 @@ export default function Achievements({ data }: Props) {
                 <div className="mt-1.5 flex items-center gap-3">
                   <div className="flex-1 bg-white/[0.08] rounded-full h-2 overflow-hidden max-w-xs">
                     <div
-                      className="h-full bg-indigo-600 rounded-full transition-all duration-700"
+                      className="h-full bg-mint-500 rounded-full transition-all duration-700"
                       style={{ width: `${progressPct(data.nextMilestone.progress.current, data.nextMilestone.progress.target)}%` }}
                     />
                   </div>
@@ -296,7 +296,7 @@ export default function Achievements({ data }: Props) {
       {/* ── Highlight stat cards ───────────────────────────────────────── */}
       <div>
         <h2 className="text-lg font-semibold mb-3 text-white/70 flex items-center gap-2">
-          <Sparkles className="w-5 h-5 text-amber-500" />
+          <Sparkles className="w-5 h-5 text-gold-500" />
           Your Financial Story
         </h2>
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
@@ -315,7 +315,7 @@ export default function Achievements({ data }: Props) {
             onClick={() => setFilter(opt.key)}
             className={`px-3 py-1 rounded-full text-xs font-medium transition ${
               filter === opt.key
-                ? 'bg-indigo-600 text-white shadow-sm'
+                ? 'bg-mint-500 text-white shadow-sm'
                 : 'bg-white/[0.05] text-white/60 hover:bg-slate-200 dark:hover:bg-slate-700'
             }`}
           >

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -50,10 +50,10 @@ interface AchievementsResult {
 
 // ── Tier styling ───────────────────────────────────────────────────────────
 const TIER_STYLES: Record<string, { ring: string; bg: string; text: string; glow: string; label: string }> = {
-  bronze:   { ring: 'ring-amber-700/40',   bg: 'from-amber-700/10 to-amber-600/5',   text: 'text-amber-700 dark:text-amber-500',   glow: 'shadow-amber-700/10',   label: 'Bronze' },
+  bronze:   { ring: 'ring-gold-700/40',   bg: 'from-gold-700/10 to-gold-600/5',   text: 'text-gold-700 dark:text-gold-500',   glow: 'shadow-gold-700/10',   label: 'Bronze' },
   silver:   { ring: 'ring-slate-400/40',   bg: 'from-slate-400/10 to-slate-300/5',   text: 'text-white/60',  glow: 'shadow-slate-400/10',   label: 'Silver' },
-  gold:     { ring: 'ring-yellow-500/40',  bg: 'from-yellow-500/10 to-amber-400/5',  text: 'text-yellow-600 dark:text-yellow-400', glow: 'shadow-yellow-500/10',  label: 'Gold' },
-  platinum: { ring: 'ring-cyan-400/40',    bg: 'from-cyan-400/10 to-blue-400/5',     text: 'text-cyan-600 dark:text-cyan-300',     glow: 'shadow-cyan-400/10',    label: 'Platinum' },
+  gold:     { ring: 'ring-gold-500/40',  bg: 'from-gold-500/10 to-gold-400/5',  text: 'text-gold-600 dark:text-gold-400', glow: 'shadow-gold-500/10',  label: 'Gold' },
+  platinum: { ring: 'ring-cyan-400/40',    bg: 'from-cyan-400/10 to-mint-400/5',     text: 'text-mint-500 dark:text-mint-300',     glow: 'shadow-cyan-400/10',    label: 'Platinum' },
 };
 
 const CATEGORY_LABELS: Record<string, string> = {

--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -197,7 +197,7 @@ export default function AddTransactionForm() {
                     setCategory('');
                     setCategoryUserTouched(true);
                   }}
-                  className="inline-flex items-center gap-1 text-[11px] font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 transition"
+                  className="inline-flex items-center gap-1 text-[11px] font-medium text-mint-500 dark:text-mint-400 hover:text-mint-600 dark:hover:text-mint-300 transition"
                   title="Suggested based on your history — click to clear"
                 >
                   <Sparkles className="w-3 h-3" />
@@ -222,7 +222,7 @@ export default function AddTransactionForm() {
               }}
               placeholder={isAutoFilled && !categoryUserTouched ? 'Auto-suggested' : 'e.g. 🏠 Kontrakan'}
               list="category-list"
-              className={isAutoFilled && !categoryUserTouched ? 'border-violet-300 dark:border-violet-700 bg-violet-50/40 dark:bg-violet-950/20' : ''}
+              className={isAutoFilled && !categoryUserTouched ? 'border-mint-400/30 bg-mint-500/5 dark:bg-mint-500/10' : ''}
             />
             <datalist id="category-list">
               {categories.map((c) => (

--- a/src/components/AlertsPanel.tsx
+++ b/src/components/AlertsPanel.tsx
@@ -30,14 +30,14 @@ const SEVERITY_ORDER: Record<Severity, number> = { high: 0, medium: 1, low: 2 };
 
 const SEVERITY_BORDER: Record<Severity, string> = {
   high: 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/30',
-  medium: 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30',
-  low: 'border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30',
+  medium: 'border-gold-400/30 bg-gold-500/5 dark:border-gold-700/40 dark:bg-gold-700/10/30',
+  low: 'border-mint-400/30 bg-mint-500/5 dark:border-mint-700/40 dark:bg-mint-700/10',
 };
 
 const SEVERITY_BADGE_CLASS: Record<Severity, string> = {
   high: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  medium: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  low: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  medium: 'bg-gold-500/10 text-gold-700 dark:bg-gold-700/20/40 dark:text-gold-300',
+  low: 'bg-mint-500/10 text-mint-600 dark:bg-mint-700/20 dark:text-mint-300',
 };
 
 const ANOMALY_REASON_LABELS: Record<Anomaly['reason'], string> = {
@@ -275,7 +275,7 @@ export default function AlertsPanel({
       
         <div className="flex items-center justify-between">
           <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <AlertTriangle className="w-4 h-4 text-amber-500" />
+            <AlertTriangle className="w-4 h-4 text-gold-500" />
             Alerts
             <div className="flex items-center gap-1.5 ml-1">
               {highCount > 0 && (
@@ -286,7 +286,7 @@ export default function AlertsPanel({
               {mediumCount > 0 && (
                 <Badge
                   variant="outline"
-                  className="text-[10px] px-1.5 py-0 border-amber-400 text-amber-600 dark:text-amber-400"
+                  className="text-[10px] px-1.5 py-0 border-gold-400 text-gold-600 dark:text-gold-400"
                 >
                   {mediumCount} approaching
                 </Badge>
@@ -294,7 +294,7 @@ export default function AlertsPanel({
               {lowCount > 0 && highCount === 0 && mediumCount === 0 && (
                 <Badge
                   variant="outline"
-                  className="text-[10px] px-1.5 py-0 border-blue-400 text-blue-600 dark:text-blue-400"
+                  className="text-[10px] px-1.5 py-0 border-mint-400 text-mint-500 dark:text-mint-400"
                 >
                   {lowCount} info
                 </Badge>

--- a/src/components/AnomalyAlerts.tsx
+++ b/src/components/AnomalyAlerts.tsx
@@ -18,14 +18,14 @@ interface Props {
 
 const SEVERITY_COLORS: Record<Anomaly['severity'], string> = {
   high: 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/30',
-  medium: 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30',
-  low: 'border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30',
+  medium: 'border-gold-400/30 bg-gold-500/5 dark:border-gold-700/40 dark:bg-gold-700/10/30',
+  low: 'border-mint-400/30 bg-mint-500/5 dark:border-mint-700/40 dark:bg-mint-700/10',
 };
 
 const SEVERITY_BADGE: Record<Anomaly['severity'], string> = {
   high: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  medium: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  low: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  medium: 'bg-gold-500/10 text-gold-700 dark:bg-gold-700/20/40 dark:text-gold-300',
+  low: 'bg-mint-500/10 text-mint-600 dark:bg-mint-700/20 dark:text-mint-300',
 };
 
 const REASON_LABELS: Record<Anomaly['reason'], string> = {
@@ -90,11 +90,11 @@ export default function AnomalyAlerts({ month }: Props) {
   const displayItems = expanded ? filtered : filtered.slice(0, 3);
 
   return (
-    <div className="glass-card p-5 border-amber-200 dark:border-amber-800">
+    <div className="glass-card p-5 border-gold-400/20 dark:border-gold-700/40">
       
         <div className="flex items-center justify-between">
           <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <AlertTriangle className="w-4 h-4 text-amber-500" />
+            <AlertTriangle className="w-4 h-4 text-gold-500" />
             Spending Anomalies Detected
           </h3>
           <div className="flex items-center gap-2">
@@ -115,8 +115,8 @@ export default function AnomalyAlerts({ month }: Props) {
                 onClick={() => toggleFilter('medium')}
                 className={`text-[10px] px-1.5 py-0 rounded-full font-medium transition cursor-pointer border ${
                   severityFilter === 'medium'
-                    ? 'bg-amber-600 text-white border-amber-600 ring-2 ring-amber-300'
-                    : 'bg-amber-100 text-amber-700 border-amber-200 hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-300 dark:border-amber-800 dark:hover:bg-amber-900/60'
+                    ? 'bg-gold-600 text-white border-gold-600 ring-2 ring-gold-400/30'
+                    : 'bg-gold-500/10 text-gold-700 border-gold-400/20 hover:bg-gold-400/20 dark:bg-gold-700/20/40 dark:text-gold-300 dark:border-gold-700/40 dark:hover:bg-gold-700/30/60'
                 }`}
               >
                 {mediumCount} medium
@@ -127,8 +127,8 @@ export default function AnomalyAlerts({ month }: Props) {
                 onClick={() => toggleFilter('low')}
                 className={`text-[10px] px-1.5 py-0 rounded-full font-medium transition cursor-pointer border ${
                   severityFilter === 'low'
-                    ? 'bg-blue-600 text-white border-blue-600 ring-2 ring-blue-300'
-                    : 'bg-blue-100 text-blue-700 border-blue-200 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-800 dark:hover:bg-blue-900/60'
+                    ? 'bg-mint-600 text-white border-mint-600 ring-2 ring-mint-400/30'
+                    : 'bg-mint-500/10 text-mint-600 border-mint-400/20 hover:bg-mint-400/20 dark:bg-mint-700/20 dark:text-mint-300 dark:border-mint-700/40 dark:hover:bg-mint-700/30/60'
                 }`}
               >
                 {lowCount} low

--- a/src/components/BudgetAlerts.tsx
+++ b/src/components/BudgetAlerts.tsx
@@ -134,7 +134,7 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
   const approachingCount = alerts.filter((a) => !a.isOver).length;
 
   return (
-    <div className="glass-card p-5 border-l-4 border-l-red-500 dark:border-l-red-400 shadow-md">
+    <div className="glass-card p-5">
       
         <div className="flex items-center justify-between">
           <h3 className="flex items-center gap-2 text-base text-white/80">

--- a/src/components/BudgetAlerts.tsx
+++ b/src/components/BudgetAlerts.tsx
@@ -146,7 +146,7 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
               </Badge>
             )}
             {approachingCount > 0 && (
-              <Badge variant="outline" className="ml-1 border-amber-400 text-amber-600 dark:text-amber-400">
+              <Badge variant="outline" className="ml-1 border-gold-400 text-gold-600 dark:text-gold-400">
                 {approachingCount} approaching
               </Badge>
             )}
@@ -170,14 +170,14 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
               const barColor = alert.isOver
                 ? 'bg-red-500'
                 : alert.pct >= 90
-                  ? 'bg-orange-500'
-                  : 'bg-amber-500';
+                  ? 'bg-coral-500/50'
+                  : 'bg-gold-500';
               const bgColor = alert.isOver
                 ? 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800'
-                : 'bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800';
+                : 'bg-gold-500/5 dark:bg-gold-700/10/30 border-gold-400/20 dark:border-gold-700/40';
               const textColor = alert.isOver
                 ? 'text-red-700 dark:text-red-300'
-                : 'text-amber-700 dark:text-amber-300';
+                : 'text-gold-700 dark:text-gold-300';
 
               return (
                 <div
@@ -207,7 +207,7 @@ export default function BudgetAlerts({ summaries, categories, activeMonth, trans
                         Over budget
                       </Badge>
                     ) : (
-                      <Badge variant="outline" className="text-xs h-5 border-amber-400 text-amber-600 dark:text-amber-400">
+                      <Badge variant="outline" className="text-xs h-5 border-gold-400 text-gold-600 dark:text-gold-400">
                         Approaching limit
                       </Badge>
                     )}

--- a/src/components/BudgetPace.tsx
+++ b/src/components/BudgetPace.tsx
@@ -53,10 +53,10 @@ interface BudgetPaceResult {
 
 const STATUS_CONFIG = {
   on_track: { label: 'On Track', color: 'text-emerald-600 dark:text-emerald-400', bg: 'bg-emerald-500', icon: CheckCircle2 },
-  warning: { label: 'Warning', color: 'text-amber-600 dark:text-amber-400', bg: 'bg-amber-500', icon: AlertTriangle },
+  warning: { label: 'Warning', color: 'text-gold-600 dark:text-gold-400', bg: 'bg-gold-500/50', icon: AlertTriangle },
   over_pace: { label: 'Over Pace', color: 'text-red-600 dark:text-red-400', bg: 'bg-red-500', icon: TrendingUp },
   critical: { label: 'Critical', color: 'text-red-700 dark:text-red-500', bg: 'bg-red-700', icon: AlertTriangle },
-  under_budget: { label: 'Under Budget', color: 'text-blue-600 dark:text-blue-400', bg: 'bg-blue-500', icon: TrendingDown },
+  under_budget: { label: 'Under Budget', color: 'text-mint-500 dark:text-mint-400', bg: 'bg-mint-500/30', icon: TrendingDown },
   no_limit: { label: 'No Limit', color: 'text-slate-500', bg: 'bg-slate-400', icon: Minus },
 } as const;
 
@@ -74,7 +74,7 @@ function PaceBar({ spent, expected, limit }: { spent: number; expected: number; 
       {/* Actual spending bar */}
       <div
         className={`absolute top-0 left-0 h-full transition-all duration-500 ${
-          spentPct > 100 ? 'bg-red-500' : spentPct > expectedPct + 5 ? 'bg-amber-500' : 'bg-emerald-500'
+          spentPct > 100 ? 'bg-red-500' : spentPct > expectedPct + 5 ? 'bg-gold-500/50' : 'bg-emerald-500'
         }`}
         style={{ width: `${spentPct}%` }}
       />
@@ -130,7 +130,7 @@ export default function BudgetPace() {
         
           <p>No budget limits set.</p>
           <p className="text-sm mt-2">
-            Set category budget limits in <a href="/settings" className="underline text-blue-500">Settings</a> to track your spending pace.
+            Set category budget limits in <a href="/settings" className="underline text-mint-500">Settings</a> to track your spending pace.
           </p>
         
       </div>
@@ -200,7 +200,7 @@ export default function BudgetPace() {
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <div className="rounded-lg border p-3 text-center">
               <p className="text-xs text-slate-400 mb-1">Pace vs Expected</p>
-              <p className={`text-lg font-bold ${data.total_pace_pct > 5 ? 'text-red-500' : data.total_pace_pct < -5 ? 'text-emerald-500' : 'text-amber-500'}`}>
+              <p className={`text-lg font-bold ${data.total_pace_pct > 5 ? 'text-red-500' : data.total_pace_pct < -5 ? 'text-emerald-500' : 'text-gold-500'}`}>
                 {data.total_pace_pct >= 0 ? '+' : ''}{data.total_pace_pct.toFixed(1)}%
               </p>
             </div>

--- a/src/components/BudgetRecommendations.tsx
+++ b/src/components/BudgetRecommendations.tsx
@@ -51,7 +51,7 @@ const CONFIDENCE_LABELS: Record<string, string> = {
 
 const CONFIDENCE_COLORS: Record<string, string> = {
   high: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20',
-  medium: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20',
+  medium: 'text-gold-600 dark:text-gold-400 bg-gold-500/5 dark:bg-gold-700/20',
   low: 'text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800',
 };
 
@@ -167,7 +167,7 @@ export default function BudgetRecommendations() {
         </div>
         <div className="glass-card p-5">
           
-            <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">{summary.noLimit}</p>
+            <p className="text-2xl font-bold text-gold-600 dark:text-gold-400">{summary.noLimit}</p>
             <p className="text-xs text-muted-foreground">No Limit Set</p>
           
         </div>
@@ -185,7 +185,7 @@ export default function BudgetRecommendations() {
         </div>
         <div className="glass-card p-5">
           
-            <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{summary.rising}</p>
+            <p className="text-2xl font-bold text-coral-500 dark:text-coral-400">{summary.rising}</p>
             <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
               <TrendingUp className="w-3 h-3" /> Rising
             </p>
@@ -201,15 +201,15 @@ export default function BudgetRecommendations() {
 
       {/* Apply All Button */}
       {needsUpdate > 0 && (
-        <div className="glass-card p-5 border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10">
+        <div className="glass-card p-5 border-gold-400/20 dark:border-gold-700/40 bg-gold-500/5 dark:bg-gold-700/10">
           
             <div className="flex items-center gap-3">
-              <Lightbulb className="w-5 h-5 text-amber-600 dark:text-amber-400" />
+              <Lightbulb className="w-5 h-5 text-gold-600 dark:text-gold-400" />
               <div>
-                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                <p className="text-sm font-medium text-gold-700 dark:text-gold-300">
                   {needsUpdate} budget{needsUpdate > 1 ? 's' : ''} could be updated
                 </p>
-                <p className="text-xs text-amber-600 dark:text-amber-400">
+                <p className="text-xs text-gold-600 dark:text-gold-400">
                   Based on {stats[0]?.periodCount ?? 0} periods of historical data
                 </p>
               </div>
@@ -217,7 +217,7 @@ export default function BudgetRecommendations() {
             <Button
               onClick={applyAllRecommendations}
               disabled={applied}
-              className="bg-amber-600 hover:bg-amber-700 text-white"
+              className="bg-gold-600 hover:bg-gold-700 text-white"
               size="sm"
             >
               {applied ? (
@@ -271,7 +271,7 @@ export default function BudgetRecommendations() {
                         isOver
                           ? 'bg-red-50/50 dark:bg-red-900/10'
                           : isNew
-                            ? 'bg-amber-50/50 dark:bg-amber-900/10'
+                            ? 'bg-gold-500/5 dark:bg-gold-700/10'
                             : undefined
                       }
                     >
@@ -289,7 +289,7 @@ export default function BudgetRecommendations() {
                       </TableCell>
                       <TableCell className="text-right">
                         {stat.trend === 'rising' ? (
-                          <span className="inline-flex items-center gap-1 text-xs font-medium text-orange-600 dark:text-orange-400">
+                          <span className="inline-flex items-center gap-1 text-xs font-medium text-coral-500 dark:text-coral-400">
                             <TrendingUp className="w-3 h-3" />
                             +{stat.trendPct}%
                           </span>
@@ -313,7 +313,7 @@ export default function BudgetRecommendations() {
                               ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800'
                               : stat.volatility === 'high'
                                 ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800'
-                                : 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800'
+                                : 'bg-gold-500/5 dark:bg-gold-700/20 text-gold-700 dark:text-gold-300 border-gold-400/20 dark:border-gold-700/40'
                           }
                         >
                           {stat.volatility}
@@ -406,7 +406,7 @@ export default function BudgetRecommendations() {
                       ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300'
                       : stat.volatility === 'high'
                         ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
-                        : 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300'
+                        : 'bg-gold-500/5 dark:bg-gold-700/20 text-gold-700 dark:text-gold-300'
                   }
                 >
                   {stat.volatility}

--- a/src/components/BudgetRecommendations.tsx
+++ b/src/components/BudgetRecommendations.tsx
@@ -124,7 +124,7 @@ export default function BudgetRecommendations() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-600 dark:border-slate-400" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40" />
       </div>
     );
   }
@@ -193,7 +193,7 @@ export default function BudgetRecommendations() {
         </div>
         <div className="glass-card p-5">
           
-            <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">{summary.highVol}</p>
+            <p className="text-2xl font-bold text-mint-600 dark:text-mint-400">{summary.highVol}</p>
             <p className="text-xs text-muted-foreground">High Volatility</p>
           
         </div>
@@ -332,7 +332,7 @@ export default function BudgetRecommendations() {
                         <span
                           className={
                             isChanged
-                              ? 'font-semibold text-indigo-600 dark:text-indigo-400'
+                              ? 'font-semibold text-mint-600 dark:text-mint-400'
                               : 'text-muted-foreground'
                           }
                         >
@@ -417,7 +417,7 @@ export default function BudgetRecommendations() {
               </div>
               <div className="flex items-center justify-between pt-1 border-t">
                 <span className="text-xs text-muted-foreground">Recommended limit:</span>
-                <span className="text-sm font-semibold text-indigo-600 dark:text-indigo-400">
+                <span className="text-sm font-semibold text-mint-600 dark:text-mint-400">
                   {formatIdr(stat.recommendedLimit)}
                 </span>
               </div>

--- a/src/components/BudgetReport.tsx
+++ b/src/components/BudgetReport.tsx
@@ -317,8 +317,8 @@ export default function BudgetReport({ summaries, categories }: Props) {
         <div className="glass-card p-5">
           
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-amber-500/10">
-                <AlertTriangle className="w-5 h-5 text-amber-400" />
+              <div className="p-2 rounded-lg bg-gold-500/10">
+                <AlertTriangle className="w-5 h-5 text-gold-400" />
               </div>
               <div>
                 <p className="text-xs text-white/40">Alerts</p>
@@ -329,7 +329,7 @@ export default function BudgetReport({ summaries, categories }: Props) {
                     </Badge>
                   )}
                   {nearLimitCount > 0 && (
-                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-gold-500/10 text-gold-700 dark:bg-gold-700/20 dark:text-gold-300">
                       {nearLimitCount} Near
                     </Badge>
                   )}
@@ -408,12 +408,12 @@ export default function BudgetReport({ summaries, categories }: Props) {
                       <TableCell className="text-right">
                         {hasLimit ? (
                           <div className="flex items-center justify-end gap-2">
-                            <span className={`text-xs font-semibold ${isOver ? 'text-red-600 dark:text-red-400' : isNear ? 'text-amber-600 dark:text-amber-400' : 'text-slate-600 dark:text-slate-300'}`}>
+                            <span className={`text-xs font-semibold ${isOver ? 'text-red-600 dark:text-red-400' : isNear ? 'text-gold-600 dark:text-gold-400' : 'text-slate-600 dark:text-slate-300'}`}>
                               {row.pct.toFixed(0)}%
                             </span>
                             <div className="w-16 bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
                               <div
-                                className={`h-1.5 rounded-full transition-all ${isOver ? 'bg-red-500' : isNear ? 'bg-amber-500' : 'bg-emerald-500'}`}
+                                className={`h-1.5 rounded-full transition-all ${isOver ? 'bg-red-500' : isNear ? 'bg-gold-500/50' : 'bg-emerald-500'}`}
                                 style={{ width: `${Math.min(100, row.pct)}%` }}
                               />
                             </div>
@@ -426,7 +426,7 @@ export default function BudgetReport({ summaries, categories }: Props) {
                         {isOver ? (
                           <Badge variant="destructive" className="text-[10px]">Over</Badge>
                         ) : isNear ? (
-                          <Badge variant="secondary" className="text-[10px] bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">Near Limit</Badge>
+                          <Badge variant="secondary" className="text-[10px] bg-gold-500/10 text-gold-700 dark:bg-gold-700/20 dark:text-gold-300">Near Limit</Badge>
                         ) : (
                           <Badge variant="secondary" className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">On Track</Badge>
                         )}

--- a/src/components/BudgetReport.tsx
+++ b/src/components/BudgetReport.tsx
@@ -481,10 +481,10 @@ export default function BudgetReport({ summaries, categories }: Props) {
                     const isOverBudget = overBudgetPeriods.has(tx.period_id);
                     const typeClass =
                       tx.type === 'cash'
-                        ? 'text-blue-600 dark:text-blue-400'
+                        ? 'text-mint-600 dark:text-mint-400'
                         : tx.type === 'credit_payment'
-                        ? 'text-amber-600 dark:text-amber-400'
-                        : 'text-purple-600 dark:text-purple-400';
+                        ? 'text-gold-600 dark:text-gold-400'
+                        : 'text-coral-500 dark:text-coral-400';
                     const typeLabel =
                       tx.type === 'cash' ? 'Cash' : tx.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
                     const dateObj = tx.created_time ? new Date(tx.created_time) : new Date(tx.date);

--- a/src/components/BudgetReport.tsx
+++ b/src/components/BudgetReport.tsx
@@ -494,7 +494,7 @@ export default function BudgetReport({ summaries, categories }: Props) {
                     return (
                       <TableRow
                         key={tx.id}
-                        className={isOverBudget ? 'border-l-2 border-l-red-500 bg-red-50/60 dark:bg-red-950/30' : ''}
+                        className={isOverBudget ? 'bg-red-50/60 dark:bg-red-950/30' : ''}
                       >
                         <TableCell className="font-medium">{tx.title}</TableCell>
                         <TableCell className="text-muted-foreground text-xs">{dateStr}</TableCell>

--- a/src/components/CashFlowWaterfall.tsx
+++ b/src/components/CashFlowWaterfall.tsx
@@ -437,7 +437,7 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
             <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">Savings Rate</span>
-                  <span className={`font-semibold ${savingsRate < 0 ? 'text-red-600 dark:text-red-400' : savingsRate < 20 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
+                  <span className={`font-semibold ${savingsRate < 0 ? 'text-red-600 dark:text-red-400' : savingsRate < 20 ? 'text-gold-600 dark:text-gold-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
                     {savingsRate.toFixed(1)}%
                   </span>
                 </div>
@@ -446,14 +446,14 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                   {/* Danger zone (0-10%) */}
                   <div className="absolute inset-0 bg-red-200 dark:bg-red-900/30" style={{ width: '10%' }} />
                   {/* Warning zone (10-20%) */}
-                  <div className="absolute inset-0 bg-amber-200 dark:bg-amber-900/30" style={{ left: '10%', width: '10%' }} />
+                  <div className="absolute inset-0 bg-gold-400/20 dark:bg-gold-700/20" style={{ left: '10%', width: '10%' }} />
                   {/* Current savings bar */}
                   <div
                     className={`absolute top-0 left-0 h-full rounded-full transition-all ${
                       savingsRate < 0
                         ? 'bg-red-500'
                         : savingsRate < 20
-                          ? 'bg-amber-500'
+                          ? 'bg-gold-500/50'
                           : 'bg-emerald-500'
                     }`}
                     style={{ width: `${Math.min(100, Math.max(0, savingsRate))}%` }}
@@ -464,7 +464,7 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                 <div className="flex justify-between text-[10px] text-muted-foreground">
                   <span>0%</span>
                   <span className="text-red-500">Risky</span>
-                  <span className="text-amber-500">Caution</span>
+                  <span className="text-gold-500">Caution</span>
                   <span className="text-emerald-500" style={{ position: 'relative', left: '0%' }}>20% target</span>
                   <span>100%</span>
                 </div>
@@ -475,7 +475,7 @@ export default function CashFlowWaterfall({ summaries, categories }: Props) {
                   </p>
                 )}
                 {savingsRate >= 0 && savingsRate < 20 && (
-                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                  <p className="text-xs text-gold-600 dark:text-gold-400 mt-2">
                     💡 Your savings rate is below the recommended 20%. Consider reducing spending in your top categories.
                   </p>
                 )}

--- a/src/components/CategoryBudgets.tsx
+++ b/src/components/CategoryBudgets.tsx
@@ -76,7 +76,7 @@ export default function CategoryBudgets({ summaries, categories, activeMonth, on
               : isOver
                 ? 'text-red-600 dark:text-red-400'
                 : pct > 80
-                  ? 'text-amber-600 dark:text-amber-400'
+                  ? 'text-gold-600 dark:text-gold-400'
                   : 'text-emerald-600 dark:text-emerald-400';
 
             return (

--- a/src/components/CategoryMatrix.tsx
+++ b/src/components/CategoryMatrix.tsx
@@ -270,7 +270,7 @@ export default function CategoryMatrix({}: Props) {
       {/* Info Banner */}
       <div className="glass-card p-5 border-mint-400/30 dark:border-mint-500/20 bg-mint-500/5 dark:bg-mint-500/10">
         <div className="flex items-start gap-3">
-            <Info className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0" />
+            <Info className="w-5 h-5 text-mint-500 mt-0.5 flex-shrink-0" />
             <div className="text-sm text-slate-600 dark:text-slate-300">
               <strong className="text-slate-800 dark:text-slate-100">How to read this:</strong>{' '}
               Each cell shows spending in a category (row) for a salary period (column).{' '}

--- a/src/components/CategoryMatrix.tsx
+++ b/src/components/CategoryMatrix.tsx
@@ -268,7 +268,7 @@ export default function CategoryMatrix({}: Props) {
   return (
     <div className="space-y-4">
       {/* Info Banner */}
-      <div className="glass-card p-5 border-blue-200 dark:border-blue-900 bg-blue-50/50 dark:bg-blue-950/20">
+      <div className="glass-card p-5 border-mint-400/30 dark:border-mint-500/20 bg-mint-500/5 dark:bg-mint-500/10">
         <div className="flex items-start gap-3">
             <Info className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0" />
             <div className="text-sm text-slate-600 dark:text-slate-300">

--- a/src/components/CategoryMatrix.tsx
+++ b/src/components/CategoryMatrix.tsx
@@ -98,7 +98,7 @@ function heatColor(amount: number, rowMax: number, categoryColor?: string): stri
   // Intensity scales from 0.12 (faint) to 0.85 (strong)
   const alpha = 0.12 + ratio * 0.73;
 
-  // Parse category color if provided, otherwise default to indigo
+  // Parse category color if provided, otherwise default to mint
   if (categoryColor) {
     const hex = categoryColor.replace('#', '');
     if (hex.length === 6) {
@@ -108,8 +108,8 @@ function heatColor(amount: number, rowMax: number, categoryColor?: string): stri
       return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
   }
-  // Default indigo
-  return `rgba(99, 102, 241, ${alpha})`;
+  // Default mint
+  return `rgba(16, 185, 129, ${alpha})`;
 }
 
 /** Text color: dark text on light backgrounds, white text when intensity is high */
@@ -285,7 +285,7 @@ export default function CategoryMatrix({}: Props) {
       {/* Matrix Table */}
       <div className="glass-card p-5">
         <h3 className="flex items-center gap-2 text-base text-white/80">
-            <Grid3x3 className="w-4 h-4 text-indigo-500" />
+            <Grid3x3 className="w-4 h-4 text-mint-500" />
             Category × Period Spending Matrix
           </h3>
         <div className="overflow-x-auto">

--- a/src/components/CategorySettings.tsx
+++ b/src/components/CategorySettings.tsx
@@ -257,7 +257,7 @@ export default function CategorySettings() {
                       </TableCell>
                       <TableCell>
                         <div className="flex gap-2">
-                          <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-500 hover:text-blue-700" onClick={() => startEdit(cat)}>
+                          <Button variant="ghost" size="sm" className="h-7 text-xs text-mint-500 hover:text-mint-600" onClick={() => startEdit(cat)}>
                             Edit
                           </Button>
                           <Button variant="ghost" size="sm" className="h-7 text-xs text-red-500 hover:text-red-700" onClick={() => handleDelete(cat.id)}>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -107,7 +107,7 @@ function highlightMatch(text: string, matchIndices: number[]): React.ReactNode {
       const start = i;
       while (i < text.length && matchSet.has(i)) i++;
       parts.push(
-        <mark key={i} className="bg-amber-200 dark:bg-amber-700 rounded-sm px-0.5 text-inherit">
+        <mark key={i} className="bg-gold-400/20 dark:bg-gold-700 rounded-sm px-0.5 text-inherit">
           {text.slice(start, i)}
         </mark>
       );

--- a/src/components/CreditCardTracker.tsx
+++ b/src/components/CreditCardTracker.tsx
@@ -280,7 +280,7 @@ export default function CreditCardTracker() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40" />
         <span className="ml-3 text-white/50">Loading credit card data...</span>
       </div>
     );

--- a/src/components/CreditCardTracker.tsx
+++ b/src/components/CreditCardTracker.tsx
@@ -290,7 +290,7 @@ export default function CreditCardTracker() {
     <div className="space-y-6">
       {/* Period Filter */}
       <div className="flex items-center gap-3">
-        <CreditCard className="w-5 h-5 text-amber-500" />
+        <CreditCard className="w-5 h-5 text-gold-500" />
         <span className="text-sm font-medium text-white/60">Period:</span>
         <Select value={selectedPeriod} onValueChange={setSelectedPeriod}>
           <SelectTrigger className="w-[180px]">
@@ -311,10 +311,10 @@ export default function CreditCardTracker() {
         <div className="glass-card p-5">
           
             <div className="flex items-center gap-2 mb-1">
-              <CreditCard className="w-4 h-4 text-amber-500" />
+              <CreditCard className="w-4 h-4 text-gold-500" />
               <span className="text-xs text-white/50">Outstanding Balance</span>
             </div>
-            <p className="text-xl font-bold text-amber-600 dark:text-amber-400">
+            <p className="text-xl font-bold text-gold-600 dark:text-gold-400">
               {formatIdr(outstandingBalance)}
             </p>
             <p className="text-xs text-white/40 mt-1">
@@ -361,10 +361,10 @@ export default function CreditCardTracker() {
         <div className="glass-card p-5">
           
             <div className="flex items-center gap-2 mb-1">
-              <Wallet className="w-4 h-4 text-blue-500" />
+              <Wallet className="w-4 h-4 text-mint-500" />
               <span className="text-xs text-white/50">Payment Coverage</span>
             </div>
-            <p className="text-xl font-bold text-blue-600 dark:text-blue-400">
+            <p className="text-xl font-bold text-mint-500 dark:text-mint-400">
               {paymentRatio.toFixed(0)}%
             </p>
             <div className="w-full bg-white/[0.08] rounded-full h-2 mt-2">
@@ -373,7 +373,7 @@ export default function CreditCardTracker() {
                   paymentRatio >= 100
                     ? 'bg-emerald-500'
                     : paymentRatio >= 70
-                      ? 'bg-amber-500'
+                      ? 'bg-gold-500/50'
                       : 'bg-red-500'
                 }`}
                 style={{ width: `${Math.min(100, paymentRatio)}%` }}
@@ -392,7 +392,7 @@ export default function CreditCardTracker() {
         <div className="glass-card p-5">
           
             <h3 className="text-base flex items-center gap-2 text-white/80">
-              <TrendingUp className="w-4 h-4 text-amber-500" />
+              <TrendingUp className="w-4 h-4 text-gold-500" />
               Credit Balance Trend
             </h3>
             <p className="text-white/50">
@@ -536,7 +536,7 @@ export default function CreditCardTracker() {
                     </TableCell>
                     <TableCell className="text-white/50">{tx.payment_method}</TableCell>
                     <TableCell>
-                      <Badge variant="outline" className="text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700 text-[10px]">
+                      <Badge variant="outline" className="text-gold-600 dark:text-gold-400 border-gold-400/30 dark:border-gold-700 text-[10px]">
                         Pending
                       </Badge>
                     </TableCell>
@@ -635,7 +635,7 @@ export default function CreditCardTracker() {
                     <TableCell className="text-right text-emerald-600 dark:text-emerald-400">
                       {formatIdr(b.payments)}
                     </TableCell>
-                    <TableCell className={`text-right font-semibold ${b.balance > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
+                    <TableCell className={`text-right font-semibold ${b.balance > 0 ? 'text-gold-600 dark:text-gold-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
                       {formatIdr(b.balance)}
                     </TableCell>
                     <TableCell>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -216,19 +216,19 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                   <div>
                     <div className="flex justify-between text-sm mb-1">
                       <span className="text-white/50">Credit Payment (Prior Month)</span>
-                      <span className="font-semibold text-amber-400">{formatIdr(activeSummary.outcome.credit_payment ?? 0)}</span>
+                      <span className="font-semibold text-gold-400">{formatIdr(activeSummary.outcome.credit_payment ?? 0)}</span>
                     </div>
                     <div className="w-full bg-white/[0.06] rounded-full h-2">
-                      <div className="bg-amber-500 h-2 rounded-full transition-all" style={{ width: `${activeSummary.outcome.total > 0 ? Math.round(((activeSummary.outcome.credit_payment ?? 0) / activeSummary.outcome.total) * 100) : 0}%` }} />
+                      <div className="bg-gold-500 h-2 rounded-full transition-all" style={{ width: `${activeSummary.outcome.total > 0 ? Math.round(((activeSummary.outcome.credit_payment ?? 0) / activeSummary.outcome.total) * 100) : 0}%` }} />
                     </div>
                   </div>
                   <div>
                     <div className="flex justify-between text-sm mb-1">
                       <span className="text-white/50">Current Month Credit Expenses</span>
-                      <span className="font-semibold text-purple-400">{formatIdr(activeSummary.outcome.credit_expenses ?? 0)}</span>
+                      <span className="font-semibold text-coral-400">{formatIdr(activeSummary.outcome.credit_expenses ?? 0)}</span>
                     </div>
                     <div className="w-full bg-white/[0.06] rounded-full h-2">
-                      <div className="bg-purple-500 h-2 rounded-full transition-all" style={{ width: `${activeSummary.outcome.total > 0 ? Math.round(((activeSummary.outcome.credit_expenses ?? 0) / activeSummary.outcome.total) * 100) : 0}%` }} />
+                      <div className="bg-coral-500 h-2 rounded-full transition-all" style={{ width: `${activeSummary.outcome.total > 0 ? Math.round(((activeSummary.outcome.credit_expenses ?? 0) / activeSummary.outcome.total) * 100) : 0}%` }} />
                     </div>
                   </div>
                   <p className="text-xs text-white/20">Credit expenses this month will be paid next month.</p>
@@ -336,7 +336,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                   {pagedTransactions.map(row => {
                     const createdDate = parseCreatedTime(row);
                     const dateStr = isNaN(createdDate.getTime()) ? row.date : createdDate.toLocaleDateString('id-ID', { year: 'numeric', month: 'short', day: 'numeric' });
-                    const typeClass = row.type === 'cash' ? 'text-cyan-400' : row.type === 'credit_payment' ? 'text-amber-400' : 'text-purple-400';
+                    const typeClass = row.type === 'cash' ? 'text-mint-400' : row.type === 'credit_payment' ? 'text-gold-400' : 'text-coral-400';
                     const typeLabel = row.type === 'cash' ? 'Cash' : row.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
                     return (
                       <TableRow key={row.id} className="border-white/[0.03] hover:bg-white/[0.03]">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -152,7 +152,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
         <section>
           {/* Period filter pill */}
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs uppercase tracking-wider text-white/20">Pulse</p>
+            <p className="text-xs uppercase tracking-wider text-white/40">Pulse</p>
             <Select value={filterPeriodId?.toString() ?? "all"} onValueChange={v => { setFilterAllTime(v === "all"); setFilterPeriodId(v === "all" ? null : parseInt(v)); setTxPage(1); }}>
               <SelectTrigger className="w-[150px] h-8 text-xs bg-white/[0.05] border-white/[0.08] text-white/60">
                 <SelectValue />
@@ -177,7 +177,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                       {glance.balance >= glance.prevBalance ? '+' : ''}{formatIdr(glance.balance - glance.prevBalance)}
                     </span>
                   )}
-                  <span className="text-xs text-white/20">vs last period</span>
+                  <span className="text-xs text-white/40">vs last period</span>
                 </div>
               </div>
             </GlassCard>
@@ -195,7 +195,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
 
         {/* ═══════════ SECTION 2: FLOW — "Ke mana duit?" ═══════════ */}
         <section>
-          <p className="text-xs uppercase tracking-wider text-white/20 mb-3">Flow</p>
+          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Flow</p>
 
           {/* Spending Pulse + Safe to Spend merged */}
           <GlassCard className="mb-4">
@@ -231,7 +231,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                       <div className="bg-coral-500 h-2 rounded-full transition-all" style={{ width: `${activeSummary.outcome.total > 0 ? Math.round(((activeSummary.outcome.credit_expenses ?? 0) / activeSummary.outcome.total) * 100) : 0}%` }} />
                     </div>
                   </div>
-                  <p className="text-xs text-white/20">Credit expenses this month will be paid next month.</p>
+                  <p className="text-xs text-white/40">Credit expenses this month will be paid next month.</p>
                 </div>
               )}
             </GlassCard>
@@ -241,7 +241,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
         {/* ═══════════ SECTION 3: ACT — "Apa yang harus dilakukan?" ═══════════ */}
         <section>
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs uppercase tracking-wider text-white/20">Act</p>
+            <p className="text-xs uppercase tracking-wider text-white/40">Act</p>
             {/* Alert bell */}
             <button onClick={() => setShowAlerts(!showAlerts)} className="relative p-2 rounded-xl hover:bg-white/10 transition">
               <Bell className="w-5 h-5 text-white/40" strokeWidth={1.8} />
@@ -278,7 +278,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
 
         {/* ═══════════ SECTION 4: INSIGHTS — "Pahami lebih dalam" ═══════════ */}
         <section>
-          <p className="text-xs uppercase tracking-wider text-white/20 mb-3">Insights</p>
+          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Insights</p>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
             {/* Net Worth mini chart */}
@@ -301,7 +301,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
                   <p className="text-xs text-white/40">months of emergency fund</p>
                 </div>
               </div>
-              <p className="text-xs text-white/20 mt-3">Based on average monthly burn rate</p>
+              <p className="text-xs text-white/40 mt-3">Based on average monthly burn rate</p>
             </GlassCard>
           </div>
 
@@ -314,7 +314,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
         {/* ═══════════ SECTION 5: FEED — Recent transactions ═══════════ */}
         <section>
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs uppercase tracking-wider text-white/20">Feed</p>
+            <p className="text-xs uppercase tracking-wider text-white/40">Feed</p>
             <a href="/transactions" className="text-xs text-white/40 hover:text-white/70 no-underline">View all →</a>
           </div>
 
@@ -380,7 +380,7 @@ export default function Dashboard({ transactions, networth, summaries }: Props) 
 
         {/* ═══════════ CHARTS — lower section ═══════════ */}
         <section>
-          <p className="text-xs uppercase tracking-wider text-white/20 mb-3">Charts</p>
+          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Charts</p>
           <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06] mb-4">
             <h3 className="text-base font-semibold text-white/80 text-white/80">Cash Outcome vs Credit Payment</h3><OutcomeChart data={filteredSummaries} /></div>
           <div className="glass-card p-5 bg-white/[0.02] border-white/[0.06] mb-4">

--- a/src/components/DataImport.tsx
+++ b/src/components/DataImport.tsx
@@ -592,7 +592,7 @@ export default function DataImport() {
             {/* File upload or paste */}
             {method === 'upload' ? (
               <div className="space-y-4">
-                <div className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-xl p-8 text-center hover:border-indigo-400 dark:hover:border-indigo-500 transition-colors">
+                <div className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-xl p-8 text-center hover:border-mint-400 dark:hover:border-mint-500 transition-colors">
                   <input
                     ref={fileInputRef}
                     type="file"
@@ -651,7 +651,7 @@ export default function DataImport() {
             )}
 
             {/* Info card */}
-            <div className="glass-card p-5 bg-indigo-50/50 dark:bg-indigo-950/20 border-indigo-200 dark:border-indigo-900">
+            <div className="glass-card p-5 bg-mint-500/5 dark:bg-mint-500/10 border-mint-400/30 dark:border-mint-500/20">
               <p className="font-medium mb-1">📋 Import Format</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   For <strong>transactions</strong>, required fields are: {requiredFields.map((f) => fieldMap[f]).join(', ')}.

--- a/src/components/DataImport.tsx
+++ b/src/components/DataImport.tsx
@@ -670,7 +670,7 @@ export default function DataImport() {
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 text-sm">
                   {fileName.endsWith('.json') ? (
-                    <FileJson className="w-4 h-4 text-amber-500" />
+                    <FileJson className="w-4 h-4 text-gold-500" />
                   ) : (
                     <FileSpreadsheet className="w-4 h-4 text-emerald-500" />
                   )}
@@ -836,8 +836,8 @@ export default function DataImport() {
                   <p className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">{result.imported}</p>
                   <p className="text-xs text-slate-500 mt-1">Imported</p>
                 </div>
-                <div className="bg-amber-50 dark:bg-amber-950/30 rounded-xl p-4 border border-amber-200 dark:border-amber-800">
-                  <p className="text-3xl font-bold text-amber-600 dark:text-amber-400">{result.skipped}</p>
+                <div className="bg-gold-500/5 dark:bg-gold-700/10 rounded-xl p-4 border border-gold-400/20 dark:border-gold-700/40">
+                  <p className="text-3xl font-bold text-gold-600 dark:text-gold-400">{result.skipped}</p>
                   <p className="text-xs text-slate-500 mt-1">Skipped</p>
                 </div>
                 <div className="bg-red-50 dark:bg-red-950/30 rounded-xl p-4 border border-red-200 dark:border-red-800">

--- a/src/components/FinancialInsights.tsx
+++ b/src/components/FinancialInsights.tsx
@@ -160,16 +160,16 @@ export default function FinancialInsights({ transactions, networth, summaries, c
 
   const typeStyles = {
     success: 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800 text-emerald-800 dark:text-emerald-300',
-    warning: 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
+    warning: 'bg-gold-500/5 dark:bg-gold-700/20 border-gold-400/20 dark:border-gold-700/40 text-gold-700 dark:text-gold-300',
     danger: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-300',
-    info: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300',
+    info: 'bg-mint-500/5 dark:bg-mint-700/20 border-mint-400/20 dark:border-mint-700/40 text-mint-600 dark:text-mint-300',
   };
 
   const badgeVariants = {
     success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' as const,
-    warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300' as const,
+    warning: 'bg-gold-500/10 text-gold-700 dark:bg-gold-700/20 dark:text-gold-300' as const,
     danger: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' as const,
-    info: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' as const,
+    info: 'bg-mint-500/10 text-mint-600 dark:bg-mint-700/20 dark:text-mint-300' as const,
   };
 
   return (

--- a/src/components/FintechSidebar.tsx
+++ b/src/components/FintechSidebar.tsx
@@ -2,6 +2,8 @@ import React, { useState, useMemo } from 'react';
 import {
   LayoutDashboard, ArrowRightLeft, PieChart, Target, Settings,
   TrendingUp, Calendar, Shield, Wallet, CreditCard, Menu, X, Bell,
+  Trophy, Flame, Heart, BarChart3, FlaskConical, Briefcase, PiggyBank,
+  Repeat, Search, FileText, GitCompare, Activity, Layers, CalendarDays, Zap, Grid3x3,
 } from 'lucide-react';
 
 interface Props {
@@ -19,10 +21,41 @@ const PRIMARY = [
 
 const SECONDARY = [
   { path: '/budget', label: 'Budget', icon: Wallet },
+  { path: '/budget-pace', label: 'Budget Pace', icon: Activity },
   { path: '/savings-rate', label: 'Savings', icon: TrendingUp },
-  { path: '/calendar', label: 'Calendar', icon: Calendar },
+  { path: '/calendar', label: 'Calendar', icon: CalendarDays },
   { path: '/runway', label: 'Runway', icon: Shield },
   { path: '/credit-card', label: 'Credit', icon: CreditCard },
+];
+
+const ANALYTICS = [
+  { path: '/streaks', label: 'Streaks', icon: Zap },
+  { path: '/achievements', label: 'Achievements', icon: Trophy },
+  { path: '/health', label: 'Health Score', icon: Heart },
+  { path: '/spending-mix', label: 'Spending Mix', icon: Layers },
+  { path: '/spending-rhythm', label: 'Rhythm', icon: BarChart3 },
+  { path: '/dna', label: 'Spending DNA', icon: FlaskConical },
+  { path: '/matrix', label: 'Category Matrix', icon: Grid3x3 },
+  { path: '/merchants', label: 'Merchants', icon: Search },
+];
+
+const PLANNING = [
+  { path: '/fire', label: 'FIRE', icon: Flame },
+  { path: '/what-if', label: 'What-If', icon: FlaskConical },
+  { path: '/forecast', label: 'Forecast', icon: TrendingUp },
+  { path: '/portfolio', label: 'Portfolio', icon: Briefcase },
+  { path: '/networth', label: 'Net Worth', icon: PiggyBank },
+];
+
+const REPORTS = [
+  { path: '/weekly', label: 'Weekly', icon: Calendar },
+  { path: '/report', label: 'Monthly', icon: FileText },
+  { path: '/yearly', label: 'Yearly', icon: CalendarDays },
+  { path: '/compare', label: 'Compare', icon: GitCompare },
+  { path: '/cashflow', label: 'Cashflow', icon: BarChart3 },
+  { path: '/recurring', label: 'Recurring', icon: Repeat },
+  { path: '/recurring-audit', label: 'Recurring Audit', icon: Search },
+  { path: '/recommendations', label: 'Tips', icon: Trophy },
 ];
 
 export default function FintechSidebar({ balance, alerts = 0 }: Props) {
@@ -103,12 +136,33 @@ export default function FintechSidebar({ balance, alerts = 0 }: Props) {
         )}
 
         {/* Primary nav */}
-        <nav className="flex-1 py-4 space-y-1 px-2 overflow-y-auto">
+        <nav className="flex-1 py-4 space-y-1 px-2 overflow-y-auto sidebar-scroll">
           {PRIMARY.map((item) => (
             <NavButton key={item.path} item={item} isPrimary />
           ))}
           <div className={`my-2 border-t ${collapsed ? 'mx-2' : 'mx-3'}`} style={{ borderColor: 'rgba(255,255,255,0.05)' }} />
           {SECONDARY.map((item) => (
+            <NavButton key={item.path} item={item} isPrimary={false} />
+          ))}
+
+          {!collapsed && (
+            <p className="px-3 pt-4 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/20">Analytics</p>
+          )}
+          {ANALYTICS.map((item) => (
+            <NavButton key={item.path} item={item} isPrimary={false} />
+          ))}
+
+          {!collapsed && (
+            <p className="px-3 pt-4 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/20">Planning</p>
+          )}
+          {PLANNING.map((item) => (
+            <NavButton key={item.path} item={item} isPrimary={false} />
+          ))}
+
+          {!collapsed && (
+            <p className="px-3 pt-4 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/20">Reports</p>
+          )}
+          {REPORTS.map((item) => (
             <NavButton key={item.path} item={item} isPrimary={false} />
           ))}
         </nav>

--- a/src/components/FireCalculator.tsx
+++ b/src/components/FireCalculator.tsx
@@ -204,7 +204,7 @@ export default function FireCalculator() {
                 step={0.5}
                 value={inf}
                 onChange={(e) => setInf(parseFloat(e.target.value))}
-                className="w-full accent-amber-600"
+                className="w-full accent-gold-600"
               />
               <div className="flex justify-between text-[10px] text-white/40">
                 <span>0%</span>
@@ -237,7 +237,7 @@ export default function FireCalculator() {
             <p className="text-2xl font-bold">{formatIdr(currentNetworth)}</p>
             <div className="w-full bg-white/[0.08] rounded-full h-2 mt-2">
               <div
-                className={`h-2 rounded-full transition-all ${progressPct >= 100 ? 'bg-emerald-500' : 'bg-blue-500'}`}
+                className={`h-2 rounded-full transition-all ${progressPct >= 100 ? 'bg-emerald-500' : 'bg-mint-500/30'}`}
                 style={{ width: `${Math.min(100, progressPct)}%` }}
               />
             </div>
@@ -311,7 +311,7 @@ export default function FireCalculator() {
                           className={`w-full rounded-t transition-all ${
                             isPastFi
                               ? 'bg-emerald-500/80 dark:bg-emerald-400/80'
-                              : 'bg-blue-500/60 dark:bg-blue-400/60'
+                              : 'bg-mint-500/30 dark:bg-mint-400/60'
                           }`}
                           style={{ height: `${barHeight}%` }}
                         />
@@ -352,7 +352,7 @@ export default function FireCalculator() {
             {/* Legend */}
             <div className="flex items-center gap-4 mt-4 text-xs text-white/50">
               <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded bg-blue-500/60" />
+                <div className="w-3 h-3 rounded bg-mint-500/30" />
                 <span>Accumulation phase</span>
               </div>
               <div className="flex items-center gap-1.5">
@@ -396,7 +396,7 @@ export default function FireCalculator() {
               </div>
               <div className="flex justify-between">
                 <span className="text-sm text-white/60">Savings Rate</span>
-                <span className={`text-sm font-semibold ${savingsRate >= 20 ? 'text-emerald-600' : savingsRate >= 0 ? 'text-amber-600' : 'text-red-600'}`}>
+                <span className={`text-sm font-semibold ${savingsRate >= 20 ? 'text-emerald-600' : savingsRate >= 0 ? 'text-gold-600' : 'text-red-600'}`}>
                   {savingsRate}%
                   {savingsRate >= 50 && <Badge className="ml-1.5 bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 text-[10px]">Super Saver</Badge>}
                 </span>
@@ -432,8 +432,8 @@ export default function FireCalculator() {
                 <span className="font-mono">{(((1 + params.expectedReturn) / (1 + params.inflation) - 1) * 100).toFixed(2)}%</span>
               </div>
               {!isFi && monthlyContributionNeeded > 0 && monthlySavings <= 0 && (
-                <div className="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
-                  <p className="text-xs text-amber-800 dark:text-amber-300 font-medium">
+                <div className="mt-3 p-3 rounded-lg bg-gold-500/5 dark:bg-gold-700/20 border border-gold-400/20 dark:border-gold-700/40">
+                  <p className="text-xs text-gold-700 dark:text-gold-300 font-medium">
                     To reach FI in 10 years, you'd need to save {formatIdr(monthlyContributionNeeded)} per month.
                   </p>
                 </div>
@@ -444,9 +444,9 @@ export default function FireCalculator() {
 
       {/* Tips Section */}
       {!isFi && (
-        <div className="glass-card p-5 border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/10">
+        <div className="glass-card p-5 border-mint-400/20 dark:border-mint-700/40 bg-mint-500/5/50 dark:bg-mint-700/10">
           <div className="flex items-start gap-3">
-              <Flame className="w-5 h-5 text-orange-500 mt-0.5 shrink-0" />
+              <Flame className="w-5 h-5 text-coral-500/50 mt-0.5 shrink-0" />
               <div>
                 <h3 className="font-semibold text-sm mb-2">Ways to reach FI faster:</h3>
                 <ul className="text-xs text-white/60 space-y-1 list-disc list-inside">

--- a/src/components/Forecast.tsx
+++ b/src/components/Forecast.tsx
@@ -82,7 +82,7 @@ interface ApiResponse {
 function ConfidenceBadge({ level }: { level: string }) {
   const colors: Record<string, string> = {
     high: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-    medium: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    medium: 'bg-gold-500/10 text-gold-700 dark:bg-gold-700/20 dark:text-gold-400',
     low: 'bg-white/[0.08] text-white/60',
   };
   return (
@@ -94,8 +94,8 @@ function ConfidenceBadge({ level }: { level: string }) {
 
 function AlertIcon({ type }: { type: string }) {
   if (type === 'danger') return <span className="text-red-500 text-lg">⚠️</span>;
-  if (type === 'warning') return <span className="text-amber-500 text-lg">⚡</span>;
-  return <span className="text-blue-500 text-lg">ℹ️</span>;
+  if (type === 'warning') return <span className="text-gold-500 text-lg">⚡</span>;
+  return <span className="text-mint-500 text-lg">ℹ️</span>;
 }
 
 function ProgressBar({ value, max, color, projectedColor }: { value: number; max: number; color: string; projectedColor?: string }) {
@@ -266,15 +266,15 @@ export default function Forecast() {
 
   const statusColors: Record<string, string> = {
     safe: 'text-emerald-600 dark:text-emerald-400',
-    warning: 'text-amber-600 dark:text-amber-400',
-    danger: 'text-orange-600 dark:text-orange-400',
+    warning: 'text-gold-600 dark:text-gold-400',
+    danger: 'text-coral-500 dark:text-coral-400',
     critical: 'text-red-600 dark:text-red-400',
   };
 
   const barStatusColors: Record<string, string> = {
     safe: 'bg-emerald-500',
-    warning: 'bg-amber-500',
-    danger: 'bg-orange-500',
+    warning: 'bg-gold-500/50',
+    danger: 'bg-coral-500/50',
     critical: 'bg-red-500',
   };
 
@@ -304,8 +304,8 @@ export default function Forecast() {
               alert.type === 'danger'
                 ? 'bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800'
                 : alert.type === 'warning'
-                ? 'bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800'
-                : 'bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800'
+                ? 'bg-gold-500/5 dark:bg-gold-700/10 border border-gold-400/20 dark:border-gold-700/40'
+                : 'bg-mint-500/5 dark:bg-mint-700/10 border border-mint-400/20 dark:border-mint-700/40'
             }`}
           >
             <AlertIcon type={alert.type} />
@@ -328,7 +328,7 @@ export default function Forecast() {
               Day {f.daysElapsed} of ~{f.periodLength} · Avg {formatIdr(f.dailyAvg)}/day
             </p>
             {f.totalUnpaid > 0 && (
-              <p className="text-xs text-orange-500 mt-1">
+              <p className="text-xs text-coral-500/50 mt-1">
                 + {formatIdr(f.totalUnpaid)} unpaid
               </p>
             )}
@@ -507,13 +507,13 @@ export default function Forecast() {
                 </span>
               </div>
               {f.creditStatus.unpaidCredit > 0 && (
-                <div className="flex justify-between text-xs text-orange-500">
+                <div className="flex justify-between text-xs text-coral-500/50">
                   <span>Unpaid credit expenses</span>
                   <span>{formatIdr(f.creditStatus.unpaidCredit)}</span>
                 </div>
               )}
               {f.creditStatus.unpaidPayments > 0 && (
-                <div className="flex justify-between text-xs text-blue-500">
+                <div className="flex justify-between text-xs text-mint-500">
                   <span>Unscheduled credit payments</span>
                   <span>{formatIdr(f.creditStatus.unpaidPayments)}</span>
                 </div>

--- a/src/components/Forecast.tsx
+++ b/src/components/Forecast.tsx
@@ -144,7 +144,7 @@ export default function Forecast() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40"></div>
         <span className="ml-3 text-white/50">Loading forecast...</span>
       </div>
     );

--- a/src/components/Forecast.tsx
+++ b/src/components/Forecast.tsx
@@ -404,7 +404,7 @@ export default function Forecast() {
           </div>
           <div className="flex items-center justify-center gap-6 mt-3 text-xs text-white/50">
             <span className="flex items-center gap-2">
-              <span className="w-4 h-0.5 bg-indigo-500 inline-block"></span> Actual
+              <span className="w-4 h-0.5 bg-mint-500 inline-block"></span> Actual
             </span>
             <span className="flex items-center gap-2">
               <span className="w-4 h-0.5 bg-red-500 inline-block border-dashed border-t border-red-500"></span> Projected

--- a/src/components/GoalTrajectory.tsx
+++ b/src/components/GoalTrajectory.tsx
@@ -97,7 +97,7 @@ export default function GoalTrajectory() {
     return (
       <div className="glass-card p-5">
         <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <Target className="w-4 h-4 text-indigo-500" />
+            <Target className="w-4 h-4 text-mint-500" />
             Proyeksi Trajectory Goal
           </h3>
           <p className="text-xs text-white/50">
@@ -112,7 +112,7 @@ export default function GoalTrajectory() {
   return (
     <div className="glass-card p-5">
       <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-          <Target className="w-4 h-4 text-indigo-500" />
+          <Target className="w-4 h-4 text-mint-500" />
           Proyeksi Trajectory Goal
         </h3>
         <p className="text-xs text-white/50">
@@ -131,7 +131,7 @@ export default function GoalTrajectory() {
             </Badge>
           )}
           {summary.atRisk > 0 && (
-            <Badge variant="outline" className="text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700">
+            <Badge variant="outline" className="text-gold-600 dark:text-gold-400 border-gold-400/30 dark:border-gold-700">
               <AlertTriangle className="w-3 h-3 mr-1" /> {summary.atRisk} Berisiko
             </Badge>
           )}
@@ -142,7 +142,7 @@ export default function GoalTrajectory() {
           )}
         </div>
       {!data.has_sufficient_data && (
-          <div className="rounded-md border border-amber-200 dark:border-amber-800/60 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 flex items-start gap-2">
+          <div className="rounded-md border border-gold-400/20 dark:border-gold-700/40/60 bg-gold-500/5 dark:bg-gold-700/20 px-3 py-2 text-xs text-gold-700 dark:text-gold-300 flex items-start gap-2">
             <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" />
             <span>
               Data networth belum cukup (butuh minimal 2 entri). Proyeksi tidak dapat dihitung —
@@ -154,7 +154,7 @@ export default function GoalTrajectory() {
         {data.has_sufficient_data && (
           <div className="rounded-md border border-white/[0.06] px-3 py-2 flex items-center justify-between gap-3">
             <div className="flex items-center gap-2 min-w-0">
-              <Gauge className="w-4 h-4 text-indigo-500 shrink-0" />
+              <Gauge className="w-4 h-4 text-mint-500 shrink-0" />
               <div className="text-xs text-muted-foreground truncate">
                 Rata-rata tabungan
               </div>
@@ -290,7 +290,7 @@ function GoalTrajectoryRowCard({ goal, hasData }: { goal: GoalTrajectoryRow; has
           value={formatDate(goal.target_date)}
         />
         <Metric
-          icon={<TrendingUp className="w-3.5 h-3.5 text-indigo-400" />}
+          icon={<TrendingUp className="w-3.5 h-3.5 text-mint-400" />}
           label="Proyeksi selesai"
           value={hasData ? formatDate(goal.projected_date) : '—'}
           valueClassName={
@@ -299,7 +299,7 @@ function GoalTrajectoryRowCard({ goal, hasData }: { goal: GoalTrajectoryRow; has
               : goal.status === 'ahead' || goal.status === 'on_track'
                 ? 'text-emerald-600 dark:text-emerald-400'
                 : goal.status === 'at_risk' || goal.status === 'behind'
-                  ? 'text-amber-600 dark:text-amber-400'
+                  ? 'text-gold-600 dark:text-gold-400'
                   : ''
           }
         />
@@ -314,7 +314,7 @@ function GoalTrajectoryRowCard({ goal, hasData }: { goal: GoalTrajectoryRow; has
           value={hasData ? paceLabel : '—'}
           valueClassName={
             hasData && paceRatio !== null && paceRatio < 1
-              ? 'text-amber-600 dark:text-amber-400'
+              ? 'text-gold-600 dark:text-gold-400'
               : hasData && paceRatio !== null && paceRatio >= 1
                 ? 'text-emerald-600 dark:text-emerald-400'
                 : ''
@@ -324,7 +324,7 @@ function GoalTrajectoryRowCard({ goal, hasData }: { goal: GoalTrajectoryRow; has
 
       {/* Recommendation */}
       {hasData && goal.projected_gap_idr > 0 && (
-        <div className="mt-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded px-2 py-1.5">
+        <div className="mt-2 text-xs text-gold-700 dark:text-gold-300 bg-gold-500/5 dark:bg-gold-700/20 rounded px-2 py-1.5">
           Kurang <strong>{formatIdr(goal.projected_gap_idr)}</strong> di tanggal target.
           Tingkatkan tabungan ke <strong>{formatIdr(goal.required_monthly)}/bln</strong> untuk tepat waktu.
         </div>
@@ -335,7 +335,7 @@ function GoalTrajectoryRowCard({ goal, hasData }: { goal: GoalTrajectoryRow; has
         </div>
       )}
       {!hasData && (
-        <div className="mt-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 rounded px-2 py-1.5">
+        <div className="mt-2 text-xs text-gold-700 dark:text-gold-300 bg-gold-500/5 dark:bg-gold-700/20 rounded px-2 py-1.5">
           Proyeksi belum tersedia. Butuh minimal 2 entri networth.
         </div>
       )}

--- a/src/components/GoalsTracker.tsx
+++ b/src/components/GoalsTracker.tsx
@@ -312,7 +312,7 @@ export default function GoalsTracker({ networth }: Props) {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="glass-card p-5">
           <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">
+              <div className="p-2 rounded-lg bg-mint-100 dark:bg-mint-900/30 text-mint-600 dark:text-mint-400">
                 <Target className="w-5 h-5" />
               </div>
               <div>
@@ -379,7 +379,7 @@ export default function GoalsTracker({ networth }: Props) {
               : 'No active goals yet — create one to get started'}
           </p>
         </div>
-        <Button onClick={openCreateDialog} className="bg-indigo-600 hover:bg-indigo-700 text-white gap-2">
+        <Button onClick={openCreateDialog} className="bg-mint-600 hover:bg-mint-700 text-white gap-2">
           <Plus className="w-4 h-4" />
           New Goal
         </Button>
@@ -701,12 +701,12 @@ export default function GoalsTracker({ networth }: Props) {
                     onClick={() => handleFormChange('icon', icon)}
                     className={`p-2 rounded-lg border transition ${
                       form.icon === icon
-                        ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 ring-1 ring-indigo-500'
+                        ? 'border-mint-500 bg-mint-50 dark:bg-mint-900/30 ring-1 ring-mint-500'
                         : 'border-white/[0.06] hover:bg-slate-50 dark:hover:bg-slate-800'
                     }`}
                     title={icon}
                   >
-                    <span className={form.icon === icon ? 'text-indigo-600 dark:text-indigo-400' : 'text-white/60'}>
+                    <span className={form.icon === icon ? 'text-mint-600 dark:text-mint-400' : 'text-white/60'}>
                       {ICON_MAP[icon]}
                     </span>
                   </button>
@@ -759,7 +759,7 @@ export default function GoalsTracker({ networth }: Props) {
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit} className="bg-indigo-600 hover:bg-indigo-700 text-white">
+            <Button onClick={handleSubmit} className="bg-mint-600 hover:bg-mint-700 text-white">
               {editingGoal ? 'Save Changes' : 'Create Goal'}
             </Button>
           </DialogFooter>

--- a/src/components/GoalsTracker.tsx
+++ b/src/components/GoalsTracker.tsx
@@ -336,7 +336,7 @@ export default function GoalsTracker({ networth }: Props) {
 
         <div className="glass-card p-5">
           <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400">
+              <div className="p-2 rounded-lg bg-gold-500/10 dark:bg-gold-700/20/30 text-gold-600 dark:text-gold-400">
                 <Clock className="w-5 h-5" />
               </div>
               <div>
@@ -499,7 +499,7 @@ export default function GoalsTracker({ networth }: Props) {
                       ) : isOnTrack ? (
                         <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
                       ) : (
-                        <Clock className="w-3.5 h-3.5 text-amber-500" />
+                        <Clock className="w-3.5 h-3.5 text-gold-500" />
                       )}
                       <span className={isOverdue ? 'text-red-600 dark:text-red-400 font-medium' : 'text-muted-foreground'}>
                         {isOverdue
@@ -560,7 +560,7 @@ export default function GoalsTracker({ networth }: Props) {
                     <div className="flex items-center gap-1">
                       <button
                         onClick={() => handleToggleComplete(goal)}
-                        className="p-1.5 rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 text-amber-500 transition"
+                        className="p-1.5 rounded-md hover:bg-gold-500/5 dark:hover:bg-gold-700/30/20 text-gold-500 transition"
                         title="Reopen goal"
                       >
                         <Circle className="w-4 h-4" />
@@ -598,7 +598,7 @@ export default function GoalsTracker({ networth }: Props) {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Surplus / Deficit</p>
-                <p className={`text-lg font-bold ${latestNetworth.total >= totalTarget ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}>
+                <p className={`text-lg font-bold ${latestNetworth.total >= totalTarget ? 'text-emerald-600 dark:text-emerald-400' : 'text-gold-600 dark:text-gold-400'}`}>
                   {latestNetworth.total >= totalTarget ? '+' : ''}{formatIdr(latestNetworth.total - totalTarget)}
                 </p>
               </div>

--- a/src/components/GoalsTracker.tsx
+++ b/src/components/GoalsTracker.tsx
@@ -301,7 +301,7 @@ export default function GoalsTracker({ networth }: Props) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40" />
       </div>
     );
   }

--- a/src/components/HealthScore.tsx
+++ b/src/components/HealthScore.tsx
@@ -285,7 +285,7 @@ export default function HealthScore({ summaries, categories }: Props) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40" />
         <span className="ml-3 text-white/50">Calculating health score...</span>
       </div>
     );

--- a/src/components/HealthScore.tsx
+++ b/src/components/HealthScore.tsx
@@ -365,7 +365,7 @@ export default function HealthScore({ summaries, categories }: Props) {
         {/* History Chart */}
         <div className="lg:col-span-2 glass-card p-6">
           <div className="flex items-center gap-2 mb-4">
-            <Trophy className="h-5 w-5 text-indigo-500" />
+            <Trophy className="h-5 w-5 text-mint-500" />
             <h3 className="text-lg font-semibold text-white/70">Score History</h3>
           </div>
           <div className="h-[220px]">
@@ -383,7 +383,7 @@ export default function HealthScore({ summaries, categories }: Props) {
       {/* Factor Breakdown */}
       <div>
         <div className="flex items-center gap-2 mb-4">
-          <Activity className="h-5 w-5 text-indigo-500" />
+          <Activity className="h-5 w-5 text-mint-500" />
           <h3 className="text-lg font-semibold text-white/70">Factor Breakdown</h3>
           <span className="text-xs text-white/40">Each factor contributes 0-20 points</span>
         </div>
@@ -396,10 +396,10 @@ export default function HealthScore({ summaries, categories }: Props) {
 
       {/* Improvement Tips */}
       {healthData.tips.length > 0 && (
-        <div className="glass-card p-5 border-indigo-200 dark:border-indigo-900 bg-indigo-50/50 dark:bg-indigo-950/20">
+        <div className="glass-card p-5 border-mint-400/30 dark:border-mint-500/20 bg-mint-500/5 dark:bg-mint-500/10">
           
             <h3 className="flex items-center gap-2 text-base text-white/80">
-              <Lightbulb className="h-5 w-5 text-indigo-500" />
+              <Lightbulb className="h-5 w-5 text-mint-500" />
               Improvement Tips
             </h3>
           
@@ -407,7 +407,7 @@ export default function HealthScore({ summaries, categories }: Props) {
             <ul className="space-y-2">
               {healthData.tips.map((tip, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm text-white/60">
-                  <span className="text-indigo-400 mt-0.5">•</span>
+                  <span className="text-mint-400 mt-0.5">•</span>
                   <span>{tip}</span>
                 </li>
               ))}

--- a/src/components/HealthScore.tsx
+++ b/src/components/HealthScore.tsx
@@ -91,25 +91,25 @@ function ScoreGauge({ score, grade, gradeColor }: { score: number; grade: string
   const bgColor = gradeColor === 'emerald' || gradeColor === 'green'
     ? 'bg-emerald-50 dark:bg-emerald-950/30'
     : gradeColor === 'yellow' || gradeColor === 'amber'
-      ? 'bg-amber-50 dark:bg-amber-950/30'
+      ? 'bg-gold-500/5 dark:bg-gold-700/10'
       : gradeColor === 'orange'
-        ? 'bg-orange-50 dark:bg-orange-950/30'
+        ? 'bg-coral-500/5 dark:bg-coral-700/10/30'
         : 'bg-red-50 dark:bg-red-950/30';
 
   const textColor = gradeColor === 'emerald' || gradeColor === 'green'
     ? 'text-emerald-700 dark:text-emerald-300'
     : gradeColor === 'yellow' || gradeColor === 'amber'
-      ? 'text-amber-700 dark:text-amber-300'
+      ? 'text-gold-700 dark:text-gold-300'
       : gradeColor === 'orange'
-        ? 'text-orange-700 dark:text-orange-300'
+        ? 'text-coral-600 dark:text-coral-300'
         : 'text-red-700 dark:text-red-300';
 
   const badgeBg = gradeColor === 'emerald' || gradeColor === 'green'
     ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200'
     : gradeColor === 'yellow' || gradeColor === 'amber'
-      ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
+      ? 'bg-gold-500/10 text-gold-700 dark:bg-gold-700/20 dark:text-gold-200'
       : gradeColor === 'orange'
-        ? 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200'
+        ? 'bg-coral-500/10 text-coral-600 dark:bg-coral-700/20 dark:text-coral-300'
         : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
 
   return (
@@ -157,9 +157,9 @@ function FactorIcon({ icon, score, maxScore }: { icon: string; score: number; ma
   const color = pct >= 80
     ? 'text-emerald-500'
     : pct >= 60
-      ? 'text-amber-500'
+      ? 'text-gold-500'
       : pct >= 40
-        ? 'text-orange-500'
+        ? 'text-coral-500/50'
         : 'text-red-500';
 
   const iconMap: Record<string, React.ReactNode> = {
@@ -178,9 +178,9 @@ function FactorCard({ factor }: { factor: HealthFactor }) {
   const barColor = pct >= 80
     ? 'bg-emerald-500'
     : pct >= 60
-      ? 'bg-amber-500'
+      ? 'bg-gold-500/50'
       : pct >= 40
-        ? 'bg-orange-500'
+        ? 'bg-coral-500/50'
         : 'bg-red-500';
 
   return (

--- a/src/components/ImportData.tsx
+++ b/src/components/ImportData.tsx
@@ -236,7 +236,7 @@ export default function ImportData() {
             <div className="text-sm font-medium">Import Result</div>
             <div className="text-sm text-muted-foreground">
               <span className="text-emerald-600 font-medium">{result.imported}</span> imported,{' '}
-              <span className="text-amber-600 font-medium">{result.skipped}</span> skipped,{' '}
+              <span className="text-gold-600 font-medium">{result.skipped}</span> skipped,{' '}
               <span className="text-red-600 font-medium">{result.errors}</span> errors
             </div>
           </div>

--- a/src/components/IncomeSettings.tsx
+++ b/src/components/IncomeSettings.tsx
@@ -219,7 +219,7 @@ export default function IncomeSettings() {
                       <TableCell className="text-right font-semibold">{formatIdr(row.income + (row.other_income ?? 0))}</TableCell>
                       <TableCell>
                         <div className="flex gap-2">
-                          <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-500 hover:text-blue-700" onClick={() => startEdit(row)}>
+                          <Button variant="ghost" size="sm" className="h-7 text-xs text-mint-500 hover:text-mint-600" onClick={() => startEdit(row)}>
                             Edit
                           </Button>
                           <Button variant="ghost" size="sm" className="h-7 text-xs text-red-500 hover:text-red-700" onClick={() => handleDelete(row.month)}>

--- a/src/components/MerchantAnalysis.tsx
+++ b/src/components/MerchantAnalysis.tsx
@@ -384,12 +384,12 @@ export default function MerchantAnalysis({
 
       {/* New Merchants Alert */}
       {newMerchants.length > 0 && viewMode === 'period' && (
-        <div className="glass-card p-5 border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
-          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300 flex items-center gap-2 text-white/80">
+        <div className="glass-card p-5 border-gold-400/20 dark:border-gold-700/40 bg-gold-500/5 dark:bg-gold-700/20">
+          <h3 className="text-sm font-semibold text-gold-700 dark:text-gold-300 flex items-center gap-2 text-white/80">
               <Sparkles className="w-4 h-4" />
               New Merchants This Period
             </h3>
-            <p className="text-xs text-amber-600 dark:text-amber-400 text-white/50">
+            <p className="text-xs text-gold-600 dark:text-gold-400 text-white/50">
               {newMerchants.length} merchant{newMerchants.length !== 1 ? 's' : ''} appearing for the first time
             </p>
           <div className="flex flex-wrap gap-2">
@@ -397,10 +397,10 @@ export default function MerchantAnalysis({
                 <Badge
                   key={m.title}
                   variant="outline"
-                  className="text-xs bg-white dark:bg-slate-800 border-amber-300 dark:border-amber-700"
+                  className="text-xs bg-white dark:bg-slate-800 border-gold-400/30 dark:border-gold-700"
                 >
                   {m.title}
-                  <span className="ml-1.5 text-amber-600 dark:text-amber-400 font-mono">
+                  <span className="ml-1.5 text-gold-600 dark:text-gold-400 font-mono">
                     {formatIdr(m.totalPaid)}
                   </span>
                 </Badge>
@@ -579,7 +579,7 @@ export default function MerchantAnalysis({
                       <div className="flex items-center gap-2">
                         <div className="flex-1 bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
                           <div
-                            className="bg-blue-500 dark:bg-blue-400 h-1.5 rounded-full transition-all"
+                            className="bg-mint-500/30 dark:bg-mint-400 h-1.5 rounded-full transition-all"
                             style={{ width: `${barWidth}%` }}
                           />
                         </div>

--- a/src/components/MonthlyReport.tsx
+++ b/src/components/MonthlyReport.tsx
@@ -241,7 +241,7 @@ export default function MonthlyReport({
                   reportSummary.savings_rate_pct >= 20
                     ? 'text-emerald-600 dark:text-emerald-400 print:text-emerald-700'
                     : reportSummary.savings_rate_pct >= 0
-                    ? 'text-amber-600 dark:text-amber-400 print:text-amber-700'
+                    ? 'text-gold-600 dark:text-gold-400 print:text-gold-700'
                     : 'text-red-600 dark:text-red-400 print:text-red-700'
                 }`}
               >
@@ -581,7 +581,7 @@ export default function MonthlyReport({
         {anomalies.length > 0 && (
           <div className="glass-card p-5 print:border print:border-gray-300 print:shadow-none">
             <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-                <AlertTriangle className="w-4 h-4 text-amber-500" />
+                <AlertTriangle className="w-4 h-4 text-gold-500" />
                 Spending Anomalies
               </h3>
             <div className="space-y-3">
@@ -590,8 +590,8 @@ export default function MonthlyReport({
                     a.severity === 'high'
                       ? 'bg-red-100 text-red-700 border-red-300'
                       : a.severity === 'medium'
-                      ? 'bg-amber-100 text-amber-700 border-amber-300'
-                      : 'bg-blue-100 text-blue-700 border-blue-300';
+                      ? 'bg-gold-500/10 text-gold-700 border-gold-400/30'
+                      : 'bg-mint-500/10 text-mint-600 border-mint-400/30';
                   return (
                     <div
                       key={a.id}
@@ -610,8 +610,8 @@ export default function MonthlyReport({
                               a.severity === 'high'
                                 ? 'border-red-300 text-red-700'
                                 : a.severity === 'medium'
-                                ? 'border-amber-300 text-amber-700'
-                                : 'border-blue-300 text-blue-700'
+                                ? 'border-gold-400/30 text-gold-700'
+                                : 'border-mint-400/30 text-mint-600'
                             }`}
                           >
                             {a.severity}

--- a/src/components/NetworthComposition.tsx
+++ b/src/components/NetworthComposition.tsx
@@ -173,7 +173,7 @@ export default function NetworthComposition({ data }: Props) {
         <div className="lg:col-span-3 glass-card p-6">
           <h2 className="text-lg font-semibold mb-2">Portfolio Allocation</h2>
           <p className="text-xs text-white/60 mb-4">
-            {latest.month} · Total: <span className="font-semibold text-violet-600 dark:text-violet-400">{formatIdr(latest.total)}</span>
+            {latest.month} · Total: <span className="font-semibold text-gold-500 dark:text-gold-400">{formatIdr(latest.total)}</span>
           </p>
           {donutData ? (
             <div className="relative h-72">

--- a/src/components/NetworthProjection.tsx
+++ b/src/components/NetworthProjection.tsx
@@ -196,7 +196,7 @@ export default function NetworthProjection({ data }: Props) {
       <div className="glass-card p-5">
         
           <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <TrendingUp className="w-4 h-4 text-violet-500" />
+            <TrendingUp className="w-4 h-4 text-gold-500" />
             Projection Settings
           </h3>
         
@@ -220,7 +220,7 @@ export default function NetworthProjection({ data }: Props) {
                     onClick={() => setProjectionMonths(m)}
                     className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
                       projectionMonths === m
-                        ? 'bg-violet-900/40 text-violet-300 ring-1 ring-violet-700'
+                        ? 'bg-gold-900/40 text-gold-300 ring-1 ring-gold-700'
                         : 'bg-white/[0.05] text-white/50 hover:bg-white/[0.08]'
                     }`}
                   >
@@ -248,7 +248,7 @@ export default function NetworthProjection({ data }: Props) {
                 step={100_000}
                 value={monthlyContribution || avgMonthlySavings}
                 onChange={(e) => setMonthlyContribution(Number(e.target.value))}
-                className="w-full h-2 bg-white/[0.08] rounded-lg appearance-none cursor-pointer accent-violet-500"
+                className="w-full h-2 bg-white/[0.08] rounded-lg appearance-none cursor-pointer accent-gold-500"
               />
               <div className="flex justify-between text-[10px] text-white/40">
                 <span>{formatIdr(0)}</span>
@@ -279,7 +279,7 @@ export default function NetworthProjection({ data }: Props) {
                 step={0.5}
                 value={annualReturnRate}
                 onChange={(e) => setAnnualReturnRate(Number(e.target.value))}
-                className="w-full h-2 bg-white/[0.08] rounded-lg appearance-none cursor-pointer accent-violet-500"
+                className="w-full h-2 bg-white/[0.08] rounded-lg appearance-none cursor-pointer accent-gold-500"
               />
               <div className="flex justify-between text-[10px] text-white/40">
                 <span>0%</span>
@@ -295,7 +295,7 @@ export default function NetworthProjection({ data }: Props) {
       <div className="glass-card p-5">
         
           <h3 className="text-base font-semibold flex items-center gap-2 text-white/80">
-            <TrendingUp className="w-4 h-4 text-violet-500" />
+            <TrendingUp className="w-4 h-4 text-gold-500" />
             Net Worth Projection
           </h3>
           <p className="text-xs text-white/50">
@@ -324,7 +324,7 @@ export default function NetworthProjection({ data }: Props) {
             <div className="glass-card p-5">
               
                 <p className="text-xs text-white/50 mb-1">In 12 Months</p>
-                <p className="text-lg font-bold text-amber-400">
+                <p className="text-lg font-bold text-gold-400">
                   {formatIdr(summary.at12)}
                 </p>
                 <p className="text-[10px] text-white/40">
@@ -341,7 +341,7 @@ export default function NetworthProjection({ data }: Props) {
             <div className="glass-card p-5">
               
                 <p className="text-xs text-white/50 mb-1">In 24 Months</p>
-                <p className="text-lg font-bold text-amber-400">
+                <p className="text-lg font-bold text-gold-400">
                   {formatIdr(summary.at24)}
                 </p>
                 <p className="text-[10px] text-white/40">
@@ -358,7 +358,7 @@ export default function NetworthProjection({ data }: Props) {
             <div className="glass-card p-5">
               
                 <p className="text-xs text-white/50 mb-1">In 36 Months</p>
-                <p className="text-lg font-bold text-amber-400">
+                <p className="text-lg font-bold text-gold-400">
                   {formatIdr(summary.at36)}
                 </p>
                 <p className="text-[10px] text-white/40">
@@ -392,7 +392,7 @@ export default function NetworthProjection({ data }: Props) {
               </div>
               <div>
                 <span className="text-white/50">Projected total: </span>
-                <span className="font-semibold text-violet-400">
+                <span className="font-semibold text-gold-400">
                   {formatIdr(summary.lastValue + summary.totalContributions + summary.investmentGains)}
                 </span>
               </div>

--- a/src/components/NetworthTable.tsx
+++ b/src/components/NetworthTable.tsx
@@ -70,7 +70,7 @@ export default function NetworthTable({ networth }: Props) {
                 )}
               </TableCell>
               <TableCell>
-                <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-500 hover:text-blue-700" asChild>
+                <Button variant="ghost" size="sm" className="h-7 text-xs text-mint-500 hover:text-mint-600" asChild>
                   <a href={`/networth/edit?month=${encodeURIComponent(row.month)}`}>Edit</a>
                 </Button>
               </TableCell>

--- a/src/components/PortfolioTracker.tsx
+++ b/src/components/PortfolioTracker.tsx
@@ -271,7 +271,7 @@ export default function PortfolioTracker() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-mint-500/40" />
       </div>
     );
   }

--- a/src/components/QuickAddDialog.tsx
+++ b/src/components/QuickAddDialog.tsx
@@ -243,7 +243,7 @@ export default function QuickAddDialog({ open, onOpenChange, onAdded }: QuickAdd
                     setCategory('');
                     setCategoryUserTouched(true);
                   }}
-                  className="inline-flex items-center gap-1 text-[11px] font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 transition"
+                  className="inline-flex items-center gap-1 text-[11px] font-medium text-mint-500 dark:text-mint-400 hover:text-mint-600 dark:hover:text-mint-300 transition"
                   title="Suggested based on your history — click to clear"
                 >
                   <Sparkles className="w-3 h-3" />
@@ -270,7 +270,7 @@ export default function QuickAddDialog({ open, onOpenChange, onAdded }: QuickAdd
               placeholder={isAutoFilled && !categoryUserTouched ? 'Auto-suggested' : 'Auto from title or pick existing'}
               list="qa-category-list"
               autoComplete="off"
-              className={isAutoFilled && !categoryUserTouched ? 'border-violet-300 dark:border-violet-700 bg-violet-50/40 dark:bg-violet-950/20' : ''}
+              className={isAutoFilled && !categoryUserTouched ? 'border-mint-400/30 dark:border-mint-500/20 bg-mint-500/5/40 dark:bg-mint-500/10/20' : ''}
             />
             <datalist id="qa-category-list">
               {categories.map((c) => (
@@ -298,7 +298,7 @@ export default function QuickAddDialog({ open, onOpenChange, onAdded }: QuickAdd
             </Badge>
           )}
           {status === 'duplicate' && (
-            <Badge variant="outline" className="w-full justify-start px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800">
+            <Badge variant="outline" className="w-full justify-start px-3 py-2 rounded-lg bg-gold-500/5 dark:bg-gold-700/20 text-gold-700 dark:text-gold-300 border-gold-400/20 dark:border-gold-700/40">
               Possible duplicate detected — similar entry in last 24h.
             </Badge>
           )}

--- a/src/components/RecurringBreakdown.tsx
+++ b/src/components/RecurringBreakdown.tsx
@@ -199,7 +199,7 @@ export default function RecurringBreakdown() {
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
           <h2 className="text-xl font-bold flex items-center gap-2">
-            <ArrowRightLeft className="w-5 h-5 text-indigo-500" />
+            <ArrowRightLeft className="w-5 h-5 text-mint-500" />
             Recurring vs Discretionary
           </h2>
           <p className="text-sm text-white/40">
@@ -266,7 +266,7 @@ export default function RecurringBreakdown() {
             <h3 className="text-sm font-medium text-white/40 text-white/80">
                 Recurring
               </h3>
-            <div className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+            <div className="text-2xl font-bold text-mint-600 dark:text-mint-400">
                 {formatIdr(currentPeriod.recurring)}
               </div>
               <p className="text-xs text-white/30 mt-1">
@@ -305,7 +305,7 @@ export default function RecurringBreakdown() {
         {/* Donut Chart */}
         <div className="glass-card p-5">
           <h3 className="text-base flex items-center gap-2 text-white/80">
-              <Repeat className="w-4 h-4 text-indigo-500" />
+              <Repeat className="w-4 h-4 text-mint-500" />
               Current Breakdown
             </h3>
             <p className="text-white/50">
@@ -358,7 +358,7 @@ export default function RecurringBreakdown() {
         {/* Trend Line */}
         <div className="glass-card p-5">
           <h3 className="text-base flex items-center gap-2 text-white/80">
-              <Zap className="w-4 h-4 text-amber-500" />
+              <Zap className="w-4 h-4 text-gold-500" />
               Trend Over Time
             </h3>
             <p className="text-white/50">
@@ -436,7 +436,7 @@ export default function RecurringBreakdown() {
       {data.topRecurring.length > 0 && (
         <div className="glass-card p-5">
           <h3 className="text-base flex items-center gap-2 text-white/80">
-              <Repeat className="w-4 h-4 text-indigo-500" />
+              <Repeat className="w-4 h-4 text-mint-500" />
               Top Recurring Expenses (All Time)
             </h3>
             <p className="text-white/50">
@@ -482,7 +482,7 @@ export default function RecurringBreakdown() {
             </p>
             <p className="text-sm text-white/30 mt-1">
               Add recurring templates in{' '}
-              <a href="/recurring" className="text-indigo-500 hover:underline">
+              <a href="/recurring" className="text-mint-500 hover:underline">
                 Settings → Recurring
               </a>{' '}
               to see the breakdown between recurring and discretionary spending.

--- a/src/components/RecurringCostAnalyzer.tsx
+++ b/src/components/RecurringCostAnalyzer.tsx
@@ -158,7 +158,7 @@ export default function RecurringCostAnalyzer() {
             No active recurring transactions found.
           </p>
           <p className="text-xs text-slate-400 mt-1">
-            Add recurring transactions on the <a href="/recurring" className="text-blue-500 hover:underline">Recurring page</a> to see your subscription cost analysis.
+            Add recurring transactions on the <a href="/recurring" className="text-mint-500 hover:underline">Recurring page</a> to see your subscription cost analysis.
           </p>
         </div>
     );
@@ -173,7 +173,7 @@ export default function RecurringCostAnalyzer() {
         <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Monthly Cost</span>
-              <DollarSign className="w-4 h-4 text-blue-500" />
+              <DollarSign className="w-4 h-4 text-mint-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{formatIdr(monthlyTotal)}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">per salary period</p>
@@ -191,7 +191,7 @@ export default function RecurringCostAnalyzer() {
         <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Active Items</span>
-              <RefreshCw className="w-4 h-4 text-amber-500" />
+              <RefreshCw className="w-4 h-4 text-gold-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{activeCount}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">
@@ -227,7 +227,7 @@ export default function RecurringCostAnalyzer() {
         {/* Insights */}
         <div className="glass-card p-5">
           <h3 className="text-sm flex items-center gap-2 text-white/80">
-              <Lightbulb className="w-4 h-4 text-amber-500" />
+              <Lightbulb className="w-4 h-4 text-gold-500" />
               Cost Insights
             </h3>
           {largestItem && (
@@ -246,9 +246,9 @@ export default function RecurringCostAnalyzer() {
               </div>
             )}
 
-            <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3 border border-blue-200 dark:border-blue-800">
+            <div className="rounded-lg bg-mint-500/5 dark:bg-mint-700/20 p-3 border border-mint-400/20 dark:border-mint-700/40">
               <div className="flex items-center gap-2 mb-1">
-                <Clock className="w-3.5 h-3.5 text-blue-500" />
+                <Clock className="w-3.5 h-3.5 text-mint-500" />
                 <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">Time Equivalence</span>
               </div>
               <p className="text-sm text-slate-600 dark:text-slate-300">
@@ -316,7 +316,7 @@ export default function RecurringCostAnalyzer() {
             {data.pausedItems.length > 0 && (
               <button
                 onClick={() => setShowPaused(!showPaused)}
-                className="text-xs text-blue-500 hover:text-blue-700 font-medium flex items-center gap-1"
+                className="text-xs text-mint-500 hover:text-mint-600 font-medium flex items-center gap-1"
               >
                 {showPaused ? 'Show active only' : `Show paused (${data.pausedItems.length})`}
                 <ArrowRight className="w-3 h-3" />
@@ -357,7 +357,7 @@ export default function RecurringCostAnalyzer() {
                     </TableCell>
                     <TableCell className="text-xs text-slate-500 dark:text-slate-400">
                       {item.isTemporary ? (
-                        <span className="text-amber-600 dark:text-amber-400">{formatEndDate(item.end_date)}</span>
+                        <span className="text-gold-600 dark:text-gold-400">{formatEndDate(item.end_date)}</span>
                       ) : (
                         formatEndDate(item.end_date)
                       )}

--- a/src/components/RecurringCostAnalyzer.tsx
+++ b/src/components/RecurringCostAnalyzer.tsx
@@ -170,7 +170,7 @@ export default function RecurringCostAnalyzer() {
     <div className="space-y-6">
       {/* ─── Summary Cards ──────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="glass-card p-5 border-l-4 border-l-blue-500">
+        <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Monthly Cost</span>
               <DollarSign className="w-4 h-4 text-blue-500" />
@@ -179,7 +179,7 @@ export default function RecurringCostAnalyzer() {
             <p className="text-[11px] text-slate-400 mt-0.5">per salary period</p>
           </div>
 
-        <div className="glass-card p-5 border-l-4 border-l-emerald-500">
+        <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Annual Cost</span>
               <Calendar className="w-4 h-4 text-emerald-500" />
@@ -188,7 +188,7 @@ export default function RecurringCostAnalyzer() {
             <p className="text-[11px] text-slate-400 mt-0.5">projected per year</p>
           </div>
 
-        <div className="glass-card p-5 border-l-4 border-l-amber-500">
+        <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Active Items</span>
               <RefreshCw className="w-4 h-4 text-amber-500" />
@@ -199,7 +199,7 @@ export default function RecurringCostAnalyzer() {
             </p>
           </div>
 
-        <div className="glass-card p-5 border-l-4 border-l-violet-500">
+        <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Avg / Item</span>
               <PieChart className="w-4 h-4 text-violet-500" />

--- a/src/components/RecurringCostAnalyzer.tsx
+++ b/src/components/RecurringCostAnalyzer.tsx
@@ -202,7 +202,7 @@ export default function RecurringCostAnalyzer() {
         <div className="glass-card p-5">
           <div className="flex items-center justify-between mb-1">
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Avg / Item</span>
-              <PieChart className="w-4 h-4 text-violet-500" />
+              <PieChart className="w-4 h-4 text-gold-500" />
             </div>
             <p className="text-xl font-bold text-slate-800 dark:text-slate-100">{formatIdr(avgPerItem)}</p>
             <p className="text-[11px] text-slate-400 mt-0.5">monthly average</p>

--- a/src/components/RecurringManager.tsx
+++ b/src/components/RecurringManager.tsx
@@ -424,7 +424,7 @@ export default function RecurringManager() {
                       </TableCell>
                       <TableCell>
                         <div className="flex gap-2">
-                          <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-500 hover:text-blue-700" onClick={() => startEdit(item)}>
+                          <Button variant="ghost" size="sm" className="h-7 text-xs text-mint-500 hover:text-mint-600" onClick={() => startEdit(item)}>
                             Edit
                           </Button>
                           <Button variant="ghost" size="sm" className="h-7 text-xs text-red-500 hover:text-red-700" onClick={() => handleDelete(item.id)}>

--- a/src/components/RunwayAnalysis.tsx
+++ b/src/components/RunwayAnalysis.tsx
@@ -66,9 +66,9 @@ const STATUS_CONFIG: Record<RunwayData['status'], {
   caution: {
     label: 'Hati-hati',
     color: '#f59e0b',
-    bgColor: 'bg-amber-50 dark:bg-amber-950/30',
-    borderColor: 'border-amber-200 dark:border-amber-800',
-    textColor: 'text-amber-700 dark:text-amber-300',
+    bgColor: 'bg-gold-500/5 dark:bg-gold-700/10',
+    borderColor: 'border-gold-400/20 dark:border-gold-700/40',
+    textColor: 'text-gold-700 dark:text-gold-300',
     gaugeColor: '#f59e0b',
     icon: <AlertTriangle className="w-5 h-5" />,
   },
@@ -84,9 +84,9 @@ const STATUS_CONFIG: Record<RunwayData['status'], {
   strong: {
     label: 'Sangat Sehat',
     color: '#06b6d4',
-    bgColor: 'bg-cyan-50 dark:bg-cyan-950/30',
-    borderColor: 'border-cyan-200 dark:border-cyan-800',
-    textColor: 'text-cyan-700 dark:text-cyan-300',
+    bgColor: 'bg-mint-500/5 dark:bg-mint-700/10/30',
+    borderColor: 'border-mint-200 dark:border-mint-800',
+    textColor: 'text-mint-600 dark:text-mint-300',
     gaugeColor: '#06b6d4',
     icon: <ShieldCheck className="w-5 h-5" />,
   },
@@ -153,7 +153,7 @@ function LiquidityBar({ breakdown }: { breakdown: AssetBreakdown[] }) {
         {sorted.map((b, i) => {
           const widthPct = (b.value / total) * 100;
           const hue = b.liquidityPct >= 0.9 ? 'bg-emerald-400'
-            : b.liquidityPct >= 0.5 ? 'bg-amber-400'
+            : b.liquidityPct >= 0.5 ? 'bg-gold-400'
             : 'bg-slate-400';
           return (
             <div
@@ -171,7 +171,7 @@ function LiquidityBar({ breakdown }: { breakdown: AssetBreakdown[] }) {
             <span
               className={`inline-block w-2 h-2 rounded-full ${
                 b.liquidityPct >= 0.9 ? 'bg-emerald-400'
-                  : b.liquidityPct >= 0.5 ? 'bg-amber-400'
+                  : b.liquidityPct >= 0.5 ? 'bg-gold-400'
                   : 'bg-slate-400'
               }`}
             />
@@ -290,21 +290,21 @@ export default function RunwayAnalysis({ periodId, compact = false }: Props) {
           </div>
           <div className="space-y-3">
             <div className="flex items-center gap-2 text-sm">
-              <Droplet className="w-4 h-4 text-blue-500 flex-shrink-0" />
+              <Droplet className="w-4 h-4 text-mint-500 flex-shrink-0" />
               <div className="flex-1">
                 <div className="text-white/50 text-xs">Aset Likuid</div>
                 <div className="font-semibold text-white/80">{formatIdr(data.liquid_assets)}</div>
               </div>
             </div>
             <div className="flex items-center gap-2 text-sm">
-              <Wallet className="w-4 h-4 text-purple-500 flex-shrink-0" />
+              <Wallet className="w-4 h-4 text-coral-500 flex-shrink-0" />
               <div className="flex-1">
                 <div className="text-white/50 text-xs">Total Aset</div>
                 <div className="font-semibold text-white/80">{formatIdr(data.total_assets)}</div>
               </div>
             </div>
             <div className="flex items-center gap-2 text-sm">
-              <CalendarClock className="w-4 h-4 text-amber-500 flex-shrink-0" />
+              <CalendarClock className="w-4 h-4 text-gold-500 flex-shrink-0" />
               <div className="flex-1">
                 <div className="text-white/50 text-xs">Pengeluaran/Bulan (rata-rata 3 bln)</div>
                 <div className="font-semibold text-white/80">{formatIdr(data.monthly_expense)}</div>
@@ -359,7 +359,7 @@ export default function RunwayAnalysis({ periodId, compact = false }: Props) {
         {compact && (
           <a
             href="/runway"
-            className="flex items-center justify-center gap-1 text-xs text-blue-500 hover:text-blue-700 dark:text-blue-400"
+            className="flex items-center justify-center gap-1 text-xs text-mint-500 hover:text-mint-600 dark:text-mint-400"
           >
             <span>Lihat detail</span>
             <ArrowRight className="w-3 h-3" />

--- a/src/components/SafeToSpend.tsx
+++ b/src/components/SafeToSpend.tsx
@@ -37,10 +37,10 @@ const STATUS_CONFIG = {
     description: 'Masih ada ruang untuk pengeluaran hari ini',
   },
   tight: {
-    accent: 'bg-amber-500',
-    text: 'text-amber-600 dark:text-amber-400',
-    bg: 'bg-amber-50 dark:bg-amber-900/20',
-    border: 'border-amber-200 dark:border-amber-800',
+    accent: 'bg-gold-500/50',
+    text: 'text-gold-600 dark:text-gold-400',
+    bg: 'bg-gold-500/5 dark:bg-gold-700/20',
+    border: 'border-gold-400/20 dark:border-gold-700/40',
     icon: <Minus className="w-4 h-4" />,
     label: 'Hemat',
     description: 'Pengeluaran hari ini melebihi batas aman',
@@ -196,8 +196,8 @@ export default function SafeToSpend({ periodId }: Props) {
                 data.remaining_budget < 0
                   ? 'bg-red-500'
                   : data.time_elapsed_pct > 80
-                    ? 'bg-amber-500'
-                    : 'bg-blue-400 dark:bg-blue-500'
+                    ? 'bg-gold-500/50'
+                    : 'bg-mint-400 dark:bg-mint-500/30'
               }`}
               style={{ width: `${Math.min(100, data.time_elapsed_pct)}%` }}
             />

--- a/src/components/SavingsRateTracker.tsx
+++ b/src/components/SavingsRateTracker.tsx
@@ -337,7 +337,7 @@ export default function SavingsRateTracker() {
           label="Average Rate"
           value={`${data.avg_rate.toFixed(1)}%`}
           subtitle={`Median ${data.median_rate.toFixed(1)}% · ${avgBench.label}`}
-          color="text-indigo-600 dark:text-indigo-400"
+          color="text-mint-500 dark:text-mint-400"
         />
         <StatCard
           icon={<Trophy className="w-5 h-5" />}
@@ -358,7 +358,7 @@ export default function SavingsRateTracker() {
           label="Total Saved"
           value={formatIdrShort(data.total_saved)}
           subtitle={`across ${data.total_periods} periods`}
-          color="text-cyan-600 dark:text-cyan-400"
+          color="text-mint-500 dark:text-mint-400"
         />
       </div>
 
@@ -402,13 +402,13 @@ export default function SavingsRateTracker() {
         {/* Streak Card */}
         <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
           <div className="flex items-center gap-2 mb-4">
-            <Flame className="w-5 h-5 text-orange-500" />
+            <Flame className="w-5 h-5 text-coral-500/50" />
             <h3 className="font-semibold">Positive Savings Streaks</h3>
           </div>
           <div className="space-y-3">
-            <div className="flex items-center justify-between p-3 rounded-lg bg-orange-50 dark:bg-orange-950/30">
+            <div className="flex items-center justify-between p-3 rounded-lg bg-coral-500/5 dark:bg-coral-700/10/30">
               <span className="text-sm font-medium">Current Streak</span>
-              <span className="text-2xl font-bold text-orange-600 dark:text-orange-400">
+              <span className="text-2xl font-bold text-coral-500 dark:text-coral-400">
                 {data.consecutive_positive}
                 <span className="text-sm font-normal ml-1">periods</span>
               </span>
@@ -434,7 +434,7 @@ export default function SavingsRateTracker() {
         {/* Benchmark Distribution */}
         <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
           <div className="flex items-center gap-2 mb-4">
-            <Award className="w-5 h-5 text-indigo-500" />
+            <Award className="w-5 h-5 text-mint-500" />
             <h3 className="font-semibold">Rate Distribution</h3>
           </div>
           <p className="text-xs text-slate-500 mb-3">How often your savings rate lands in each tier</p>
@@ -460,7 +460,7 @@ export default function SavingsRateTracker() {
       {/* === Milestones === */}
       <div className="bg-white dark:bg-slate-800 rounded-xl p-5 shadow-sm border border-slate-200 dark:border-slate-700">
         <div className="flex items-center gap-2 mb-4">
-          <Award className="w-5 h-5 text-amber-500" />
+          <Award className="w-5 h-5 text-gold-500" />
           <h3 className="font-semibold">Savings Milestones</h3>
           <span className="text-xs text-slate-500 ml-auto">Based on your best rate: {data.best_rate.toFixed(1)}%</span>
         </div>
@@ -470,12 +470,12 @@ export default function SavingsRateTracker() {
               key={m.label}
               className={`p-4 rounded-xl text-center transition ${
                 m.achieved
-                  ? 'bg-gradient-to-br from-amber-50 to-yellow-50 dark:from-amber-950/40 dark:to-yellow-950/40 border-2 border-amber-300 dark:border-amber-700'
+                  ? 'bg-gradient-to-br from-gold-500/5 to-gold-500/5 dark:from-gold-700/10/40 dark:to-gold-700/5/40 border-2 border-gold-400/30 dark:border-gold-700'
                   : 'bg-slate-50 dark:bg-slate-700/50 border-2 border-transparent opacity-60'
               }`}
             >
               <div className={`text-3xl mb-1 ${m.achieved ? '' : 'grayscale'}`}>{m.icon}</div>
-              <div className={`text-sm font-bold ${m.achieved ? 'text-amber-700 dark:text-amber-400' : 'text-slate-500'}`}>
+              <div className={`text-sm font-bold ${m.achieved ? 'text-gold-700 dark:text-gold-400' : 'text-slate-500'}`}>
                 {m.label}
               </div>
               <div className="text-[10px] text-slate-400 mt-1 leading-tight">{m.desc}</div>

--- a/src/components/SpendingAnalytics.tsx
+++ b/src/components/SpendingAnalytics.tsx
@@ -346,7 +346,7 @@ export default function SpendingAnalytics({ summaries, categories }: Props) {
       {/* ─── Velocity / KPI Row ─────────────────────────────────── */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="glass-card p-4">
-          <Zap className="w-4 h-4 text-indigo-400 mb-1.5" />
+          <Zap className="w-4 h-4 text-mint-400 mb-1.5" />
           <span className="text-[10px] font-medium text-white/40 uppercase tracking-wider">Avg Daily</span>
           <div className="text-xl font-bold text-white mt-1">{formatIdr(velocity.current_avg_daily)}</div>
           <div className={`text-xs mt-1 ${velocityUp ? 'text-red-400' : 'text-emerald-400'}`}>
@@ -362,14 +362,14 @@ export default function SpendingAnalytics({ summaries, categories }: Props) {
         </div>
 
         <div className="glass-card p-4">
-          <Clock className="w-4 h-4 text-amber-400 mb-1.5" />
+          <Clock className="w-4 h-4 text-gold-400 mb-1.5" />
           <span className="text-[10px] font-medium text-white/40 uppercase tracking-wider">Cumulative</span>
           <div className="text-xl font-bold text-white mt-1">{formatIdr(velocity.cumulative_spend)}</div>
           <div className="text-xs text-white/30 mt-1">Over {velocity.days_tracked} tracked days</div>
         </div>
 
         <div className="glass-card p-4">
-          <Hash className="w-4 h-4 text-blue-400 mb-1.5" />
+          <Hash className="w-4 h-4 text-mint-400 mb-1.5" />
           <span className="text-[10px] font-medium text-white/40 uppercase tracking-wider">Transactions</span>
           <div className="text-xl font-bold text-white mt-1">{stats.count}</div>
           <div className="text-xs text-white/30 mt-1">
@@ -476,13 +476,13 @@ export default function SpendingAnalytics({ summaries, categories }: Props) {
           </TableHeader>
           <TableBody>
             <TableRow><TableCell className="text-white/60">Total Paid Spending</TableCell><TableCell className="text-right font-semibold text-white/90">{formatIdr(stats.paid_amount)}</TableCell></TableRow>
-            <TableRow><TableCell className="text-white/60">Unpaid Total</TableCell><TableCell className="text-right font-semibold text-amber-400">{formatIdr(stats.unpaid_amount)}</TableCell></TableRow>
+            <TableRow><TableCell className="text-white/60">Unpaid Total</TableCell><TableCell className="text-right font-semibold text-gold-400">{formatIdr(stats.unpaid_amount)}</TableCell></TableRow>
             <TableRow><TableCell className="text-white/60">Average Transaction (paid)</TableCell><TableCell className="text-right text-white/80">{formatIdr(stats.avg_amount)}</TableCell></TableRow>
             <TableRow><TableCell className="text-white/60">Median Transaction (paid)</TableCell><TableCell className="text-right text-white/80">{formatIdr(stats.median_amount)}</TableCell></TableRow>
             <TableRow><TableCell className="text-white/60">Largest Transaction</TableCell><TableCell className="text-right"><span className="font-semibold text-white/90">{formatIdr(stats.max_amount)}</span>{stats.largest_title && <span className="text-xs text-white/30 ml-2">{stats.largest_title}</span>}</TableCell></TableRow>
             <TableRow><TableCell className="text-white/60">Smallest Transaction</TableCell><TableCell className="text-right"><span className="font-semibold text-white/90">{formatIdr(stats.min_amount)}</span>{stats.smallest_title && <span className="text-xs text-white/30 ml-2">{stats.smallest_title}</span>}</TableCell></TableRow>
             <TableRow><TableCell className="text-white/60">Total Transactions</TableCell><TableCell className="text-right text-white/80">{stats.count}</TableCell></TableRow>
-            <TableRow><TableCell className="text-white/60">Paid / Unpaid</TableCell><TableCell className="text-right"><span className="text-emerald-400">{stats.paid_count}</span><span className="text-white/30 mx-1">/</span><span className="text-amber-400">{stats.unpaid_count}</span></TableCell></TableRow>
+            <TableRow><TableCell className="text-white/60">Paid / Unpaid</TableCell><TableCell className="text-right"><span className="text-emerald-400">{stats.paid_count}</span><span className="text-white/30 mx-1">/</span><span className="text-gold-400">{stats.unpaid_count}</span></TableCell></TableRow>
           </TableBody>
         </Table>
       </div>

--- a/src/components/SpendingCalendar.tsx
+++ b/src/components/SpendingCalendar.tsx
@@ -209,7 +209,7 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
     const ratio = total / maxDaily;
     if (ratio <= 0.25) return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400';
     if (ratio <= 0.5) return 'bg-emerald-200 dark:bg-emerald-800/40 text-emerald-800 dark:text-emerald-300';
-    if (ratio <= 0.75) return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400';
+    if (ratio <= 0.75) return 'bg-gold-500/10 dark:bg-gold-700/20/30 text-gold-700 dark:text-gold-400';
     return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
   };
 
@@ -259,7 +259,7 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
             <span>Low</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded-sm bg-amber-100 dark:bg-amber-900/30" />
+            <span className="inline-block w-3 h-3 rounded-sm bg-gold-500/10 dark:bg-gold-700/20/30" />
             <span>Medium</span>
           </div>
           <div className="flex items-center gap-1.5">
@@ -306,12 +306,12 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
                   aspect-square rounded-lg border transition-all hover:scale-105 hover:shadow-sm
                   flex flex-col items-center justify-center gap-0.5
                   ${heatClass}
-                  ${isToday ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-navy-950' : 'border-white/[0.06]'}
+                  ${isToday ? 'ring-2 ring-mint-500 ring-offset-1 ring-offset-navy-950' : 'border-white/[0.06]'}
                   ${count > 0 ? 'cursor-pointer' : 'cursor-default'}
                   ${isMonthBoundary ? 'ring-1 ring-white/10' : ''}
                 `}
               >
-                <span className={`text-xs font-medium ${isToday ? 'text-blue-400' : ''}`}>
+                <span className={`text-xs font-medium ${isToday ? 'text-mint-400' : ''}`}>
                   {date.getDate()}
                 </span>
                 {showMonthLabel && (
@@ -394,10 +394,10 @@ export default function SpendingCalendar({ transactions, periods }: Props) {
                     .map((tx) => {
                       const typeClass =
                         tx.type === 'cash'
-                          ? 'text-blue-600 dark:text-blue-400'
+                          ? 'text-mint-500 dark:text-mint-400'
                           : tx.type === 'credit_payment'
-                          ? 'text-amber-600 dark:text-amber-400'
-                          : 'text-purple-600 dark:text-purple-400';
+                          ? 'text-gold-600 dark:text-gold-400'
+                          : 'text-coral-500 dark:text-coral-400';
                       const typeLabel =
                         tx.type === 'cash' ? 'Cash' : tx.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
                       return (

--- a/src/components/SpendingDna.tsx
+++ b/src/components/SpendingDna.tsx
@@ -114,7 +114,7 @@ const dimensionColors: Record<keyof DnaDimensions, string> = {
   savingsDiscipline: 'bg-emerald-500',
   creditUsage: 'bg-amber-500',
   stability: 'bg-sky-500',
-  growth: 'bg-violet-500',
+  growth: 'bg-gold-500',
 };
 
 const dimensionIcons: Record<keyof DnaDimensions, React.ReactNode> = {
@@ -369,11 +369,11 @@ export default function SpendingDna() {
   return (
     <div className="space-y-6">
       {/* ── Personality Type Hero ──────────────────────────────────────── */}
-      <div className="glass-card p-5 border-violet-200 dark:border-violet-800 bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-slate-800 dark:to-slate-900">
+      <div className="glass-card p-5 border-white/[0.08] bg-gradient-to-br dark:from-navy-800/40 dark:to-navy-900/20">
         <div className="flex flex-col md:flex-row items-center gap-6">
             <div className="text-7xl">{data.personality.emoji}</div>
             <div className="flex-1 text-center md:text-left">
-              <h2 className="text-2xl font-bold text-violet-900 dark:text-violet-200">
+              <h2 className="text-2xl font-bold text-gold-400 dark:text-gold-400">
                 {data.personality.type}
               </h2>
               <p className="text-slate-600 dark:text-slate-400 mt-2 max-w-xl">
@@ -395,7 +395,7 @@ export default function SpendingDna() {
               </div>
             </div>
             <div className="flex-shrink-0">
-              <Trophy className="w-16 h-16 text-violet-300 dark:text-violet-700" />
+              <Trophy className="w-16 h-16 text-gold-400 dark:text-gold-500" />
             </div>
           </div>
         </div>
@@ -404,7 +404,7 @@ export default function SpendingDna() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="glass-card p-5">
           <h3 className="flex items-center gap-2 text-white/80">
-              <Brain className="w-5 h-5 text-violet-500" />
+              <Brain className="w-5 h-5 text-gold-500" />
               Behavioral Radar
             </h3>
           <div style={{ height: 320, maxWidth: 380, margin: '0 auto' }}>
@@ -442,7 +442,7 @@ export default function SpendingDna() {
       {/* ── Key Insights ──────────────────────────────────────────────── */}
       <div className="glass-card p-5">
         <h3 className="flex items-center gap-2 text-white/80">
-            <Zap className="w-5 h-5 text-amber-500" />
+            <Zap className="w-5 h-5 text-gold-500" />
             Key Insights
           </h3>
         <div className="space-y-3">
@@ -451,7 +451,7 @@ export default function SpendingDna() {
                 key={i}
                 className="flex gap-3 items-start p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50"
               >
-                <ArrowRight className="w-4 h-4 text-violet-500 mt-0.5 flex-shrink-0" />
+                <ArrowRight className="w-4 h-4 text-gold-500 mt-0.5 flex-shrink-0" />
                 <p className="text-sm text-slate-700 dark:text-slate-300">{insight}</p>
               </div>
             ))}

--- a/src/components/SpendingDna.tsx
+++ b/src/components/SpendingDna.tsx
@@ -110,9 +110,9 @@ const dimensionLabels: Record<keyof DnaDimensions, string> = {
 
 const dimensionColors: Record<keyof DnaDimensions, string> = {
   necessities: 'bg-slate-500',
-  lifestyle: 'bg-pink-500',
+  lifestyle: 'bg-coral-500',
   savingsDiscipline: 'bg-emerald-500',
-  creditUsage: 'bg-amber-500',
+  creditUsage: 'bg-gold-500/50',
   stability: 'bg-sky-500',
   growth: 'bg-gold-500',
 };
@@ -326,14 +326,14 @@ export default function SpendingDna() {
   const loyaltyColor = (score: number) => {
     if (score >= 80) return 'text-emerald-600 dark:text-emerald-400';
     if (score >= 60) return 'text-sky-600 dark:text-sky-400';
-    if (score >= 40) return 'text-amber-600 dark:text-amber-400';
+    if (score >= 40) return 'text-gold-600 dark:text-gold-400';
     return 'text-rose-600 dark:text-rose-400';
   };
 
   const loyaltyBg = (score: number) => {
     if (score >= 80) return 'bg-emerald-500';
     if (score >= 60) return 'bg-sky-500';
-    if (score >= 40) return 'bg-amber-500';
+    if (score >= 40) return 'bg-gold-500/50';
     return 'bg-rose-500';
   };
 
@@ -478,7 +478,7 @@ export default function SpendingDna() {
 
         <div className="glass-card p-5">
           <h3 className="flex items-center gap-2 text-white/80">
-              <Target className="w-5 h-5 text-pink-500" />
+              <Target className="w-5 h-5 text-coral-500" />
               Recurring vs Discretionary Split
             </h3>
           {compositionChartData ? (

--- a/src/components/SpendingPulse.tsx
+++ b/src/components/SpendingPulse.tsx
@@ -117,11 +117,11 @@ export default function SpendingPulse({ summaries, activeMonth }: Props) {
       badge: 'Under Pace',
     },
     'on-track': {
-      color: 'text-amber-600 dark:text-amber-400',
-      bg: 'bg-amber-50 dark:bg-amber-900/20',
-      border: 'border-amber-200 dark:border-amber-800',
-      bar: 'bg-amber-500',
-      track: 'bg-amber-100 dark:bg-amber-800/50',
+      color: 'text-gold-600 dark:text-gold-400',
+      bg: 'bg-gold-500/5 dark:bg-gold-700/20/20',
+      border: 'border-gold-400/20 dark:border-gold-700/40',
+      bar: 'bg-gold-500/50',
+      track: 'bg-gold-500/10 dark:bg-gold-700/20/50',
       icon: <Activity className="w-5 h-5" />,
       label: 'Spending on pace with the period',
       badge: 'On Track',
@@ -208,25 +208,25 @@ export default function SpendingPulse({ summaries, activeMonth }: Props) {
                   Cash vs Credit
                 </div>
                 <div className="flex items-baseline gap-2 mb-1">
-                  <span className="text-sm font-semibold text-blue-600 dark:text-blue-400">
+                  <span className="text-sm font-semibold text-mint-500 dark:text-mint-400">
                     {formatIdr(pulse.cash)}
                   </span>
                   <span className="text-slate-400 dark:text-slate-500">/</span>
-                  <span className="text-sm font-semibold text-amber-600 dark:text-amber-400">
+                  <span className="text-sm font-semibold text-gold-600 dark:text-gold-400">
                     {formatIdr(pulse.credit)}
                   </span>
                 </div>
                 <div className="flex gap-0.5 text-[10px] text-slate-500 mb-1">
-                  <span className="text-blue-500">● Cash</span>
-                  <span className="text-amber-500 ml-1">● Credit</span>
+                  <span className="text-mint-500">● Cash</span>
+                  <span className="text-gold-500 ml-1">● Credit</span>
                 </div>
                 <div className="flex-1 bg-slate-200 dark:bg-slate-700 rounded-full h-1.5 overflow-hidden flex">
                   <div
-                    className="bg-blue-500 h-1.5 rounded-l-full transition-all"
+                    className="bg-mint-500/30 h-1.5 rounded-l-full transition-all"
                     style={{ width: `${(pulse.cash / Math.max(1, pulse.cash + pulse.credit)) * 100}%` }}
                   />
                   <div
-                    className="bg-amber-500 h-1.5 rounded-r-full transition-all"
+                    className="bg-gold-500/50 h-1.5 rounded-r-full transition-all"
                     style={{ width: `${(pulse.credit / Math.max(1, pulse.cash + pulse.credit)) * 100}%` }}
                   />
                 </div>
@@ -297,7 +297,7 @@ export default function SpendingPulse({ summaries, activeMonth }: Props) {
           <span className="w-16 text-slate-500 dark:text-slate-400 shrink-0">Time</span>
           <div className="flex-1 bg-slate-200 dark:bg-slate-700 rounded-full h-1.5">
             <div
-              className="bg-blue-400 dark:bg-blue-500 h-1.5 rounded-full transition-all"
+              className="bg-mint-400 dark:bg-mint-500/30 h-1.5 rounded-full transition-all"
               style={{ width: `${pulse.pctTimeElapsed}%` }}
             />
           </div>
@@ -323,7 +323,7 @@ export default function SpendingPulse({ summaries, activeMonth }: Props) {
                 (pulse.actualSpend / pulse.income) * 100 < 50
                   ? 'bg-emerald-500'
                   : (pulse.actualSpend / pulse.income) * 100 <= 80
-                    ? 'bg-amber-500'
+                    ? 'bg-gold-500/50'
                     : 'bg-red-500'
               }`}
               style={{ width: `${Math.min(100, (pulse.actualSpend / pulse.income) * 100)}%` }}
@@ -333,7 +333,7 @@ export default function SpendingPulse({ summaries, activeMonth }: Props) {
             (pulse.actualSpend / pulse.income) * 100 < 50
               ? 'text-emerald-600 dark:text-emerald-400'
               : (pulse.actualSpend / pulse.income) * 100 <= 80
-                ? 'text-amber-600 dark:text-amber-400'
+                ? 'text-gold-600 dark:text-gold-400'
                 : 'text-red-600 dark:text-red-400'
           }`}>
             {((pulse.actualSpend / pulse.income) * 100).toFixed(0)}%

--- a/src/components/SpendingRhythm.tsx
+++ b/src/components/SpendingRhythm.tsx
@@ -91,7 +91,7 @@ function fmtDateRange(start: string | null, end: string | null): string {
 
 function toneClasses(tone: 'good' | 'neutral' | 'warn'): string {
   if (tone === 'good') return 'border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/30';
-  if (tone === 'warn') return 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30';
+  if (tone === 'warn') return 'border-gold-400/20 dark:border-gold-700/40 bg-gold-500/5 dark:bg-gold-700/10';
   return 'border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50';
 }
 
@@ -410,7 +410,7 @@ export default function SpendingRhythm() {
               className={`rounded-lg border p-4 ${
                 bucket.label === 'Late Night' ? 'border-navy-300 dark:border-navy-700 bg-navy-500/5 dark:bg-navy-500/10'
                 : bucket.label === 'Morning' ? 'border-gold-400/30 bg-gold-500/5 dark:bg-gold-500/10'
-                : bucket.label === 'Afternoon' ? 'border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/30'
+                : bucket.label === 'Afternoon' ? 'border-coral-400/20 dark:border-coral-700/40 bg-coral-500/5 dark:bg-coral-700/10/30'
                 : 'border-gold-400/30 bg-gold-500/5 dark:bg-gold-500/10'
               }`}
             >
@@ -426,7 +426,7 @@ export default function SpendingRhythm() {
                   className={`h-full rounded-full ${
                     bucket.label === 'Late Night' ? 'bg-navy-400'
                     : bucket.label === 'Morning' ? 'bg-gold-400'
-                    : bucket.label === 'Afternoon' ? 'bg-orange-400'
+                    : bucket.label === 'Afternoon' ? 'bg-coral-400'
                     : 'bg-gold-400'
                   }`}
                   style={{ width: `${bucket.pctOfTx}%` }}

--- a/src/components/SpendingRhythm.tsx
+++ b/src/components/SpendingRhythm.tsx
@@ -188,12 +188,12 @@ export default function SpendingRhythm() {
   function heatColor(value: number): string {
     if (value === 0) return 'rgba(148, 163, 184, 0.1)'; // slate-400/10
     const ratio = Math.min(1, value / heatmapMax);
-    // Interpolate from sky-100 → indigo-600
-    if (ratio > 0.75) return 'rgba(67, 56, 202, 0.85)';   // indigo-700
-    if (ratio > 0.5) return 'rgba(79, 70, 229, 0.75)';    // indigo-600
-    if (ratio > 0.25) return 'rgba(99, 102, 241, 0.6)';   // indigo-500
-    if (ratio > 0.1) return 'rgba(129, 140, 248, 0.5)';   // indigo-400
-    return 'rgba(165, 180, 252, 0.4)';                    // indigo-300
+    // Interpolate from mint-100 → mint-600
+    if (ratio > 0.75) return 'rgba(5, 150, 105, 0.85)';   // mint-600
+    if (ratio > 0.5) return 'rgba(4, 120, 87, 0.75)';     // mint-700
+    if (ratio > 0.25) return 'rgba(16, 185, 129, 0.6)';   // mint-500
+    if (ratio > 0.1) return 'rgba(52, 211, 153, 0.5)';    // mint-400
+    return 'rgba(110, 231, 183, 0.4)';                    // mint-300
   }
 
   // ── Early returns AFTER all hooks ──
@@ -201,7 +201,7 @@ export default function SpendingRhythm() {
     return (
       <div className="flex items-center justify-center py-20 text-slate-400">
         <div className="text-center">
-          <div className="inline-block w-8 h-8 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin mb-3"></div>
+          <div className="inline-block w-8 h-8 border-2 border-mint-500/40 border-t-transparent rounded-full animate-spin mb-3"></div>
           <p className="text-sm">Analyzing your spending rhythm…</p>
         </div>
       </div>
@@ -252,12 +252,12 @@ export default function SpendingRhythm() {
           <p className="text-xs text-slate-400 mt-0.5">{data.dowStats.length} weekdays tracked</p>
         </div>
 
-        <div className="rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/30 p-4">
-          <div className="flex items-center gap-2 text-xs text-indigo-600 dark:text-indigo-400 mb-1">
+        <div className="rounded-xl border border-mint-400/30 bg-mint-500/5 dark:bg-mint-500/10 p-4">
+          <div className="flex items-center gap-2 text-xs text-mint-600 dark:text-mint-400 mb-1">
             <Zap className="w-3.5 h-3.5" /> Peak Day
           </div>
-          <p className="text-2xl font-bold text-indigo-700 dark:text-indigo-300">{data.peakDay?.label ?? '—'}</p>
-          <p className="text-xs text-indigo-500/70 mt-0.5">{data.peakDay ? `${formatIdr(data.peakDay.avgPerDay)}/day avg` : 'no data'}</p>
+          <p className="text-2xl font-bold text-mint-700 dark:text-mint-300">{data.peakDay?.label ?? '—'}</p>
+          <p className="text-xs text-mint-500/70 mt-0.5">{data.peakDay ? `${formatIdr(data.peakDay.avgPerDay)}/day avg` : 'no data'}</p>
         </div>
 
         <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/30 p-4">
@@ -277,7 +277,7 @@ export default function SpendingRhythm() {
       {data.insights.length > 0 && (
         <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
           <h3 className="flex items-center gap-2 text-sm font-semibold mb-3">
-            <Lightbulb className="w-4 h-4 text-amber-500" />
+            <Lightbulb className="w-4 h-4 text-gold-500" />
             Behavioral Insights
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -298,7 +298,7 @@ export default function SpendingRhythm() {
       <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
           <h3 className="flex items-center gap-2 text-sm font-semibold">
-            <Calendar className="w-4 h-4 text-indigo-500" />
+            <Calendar className="w-4 h-4 text-mint-500" />
             Spending by Day of Week
           </h3>
           <div className="flex gap-1 text-xs bg-slate-100 dark:bg-slate-700/50 rounded-lg p-1">
@@ -308,7 +308,7 @@ export default function SpendingRhythm() {
                 onClick={() => setDowMetric(key)}
                 className={`px-2.5 py-1 rounded-md font-medium transition ${
                   dowMetric === key
-                    ? 'bg-white dark:bg-slate-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                    ? 'bg-white dark:bg-slate-800 text-mint-600 dark:text-mint-400 shadow-sm'
                     : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
                 }`}
               >
@@ -324,10 +324,10 @@ export default function SpendingRhythm() {
 
         <div className="flex items-center gap-4 mt-3 text-xs text-slate-400">
           <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded bg-blue-500/70"></span> Weekday
+            <span className="inline-block w-3 h-3 rounded bg-mint-500/70"></span> Weekday
           </span>
           <span className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 rounded bg-purple-500/70"></span> Weekend
+            <span className="inline-block w-3 h-3 rounded bg-coral-500/70"></span> Weekend
           </span>
         </div>
       </div>
@@ -335,13 +335,13 @@ export default function SpendingRhythm() {
       {/* ── Weekday vs Weekend ── */}
       <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
         <h3 className="flex items-center gap-2 text-sm font-semibold mb-4">
-          <Calendar className="w-4 h-4 text-purple-500" />
+          <Calendar className="w-4 h-4 text-coral-500" />
           Weekday vs Weekend
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Weekday */}
-          <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 p-4">
-            <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-3">💼 WEEKDAYS (Mon–Fri)</p>
+          <div className="rounded-lg border border-mint-400/30 bg-mint-500/5 dark:bg-mint-500/10 p-4">
+            <p className="text-xs font-semibold text-mint-600 dark:text-mint-400 mb-3">💼 WEEKDAYS (Mon–Fri)</p>
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
                 <span className="text-slate-500 dark:text-slate-400">Total Spend</span>
@@ -355,21 +355,21 @@ export default function SpendingRhythm() {
                 <span className="text-slate-500 dark:text-slate-400">Avg / Day</span>
                 <span className="font-semibold">{formatIdr(wv.weekdayAvgPerDay)}</span>
               </div>
-              <div className="pt-2 border-t border-blue-200 dark:border-blue-800">
+              <div className="pt-2 border-t border-mint-400/30">
                 <div className="flex justify-between text-xs mb-1">
                   <span className="text-slate-400">Share of spend</span>
-                  <span className="font-medium text-blue-600 dark:text-blue-400">{wv.weekdayPctSpend}%</span>
+                  <span className="font-medium text-mint-600 dark:text-mint-400">{wv.weekdayPctSpend}%</span>
                 </div>
-                <div className="h-2 rounded-full bg-blue-100 dark:bg-blue-900/40 overflow-hidden">
-                  <div className="h-full bg-blue-500 rounded-full" style={{ width: `${wv.weekdayPctSpend}%` }}></div>
+                <div className="h-2 rounded-full bg-mint-100 dark:bg-mint-900/40 overflow-hidden">
+                  <div className="h-full bg-mint-500 rounded-full" style={{ width: `${wv.weekdayPctSpend}%` }}></div>
                 </div>
               </div>
             </div>
           </div>
 
           {/* Weekend */}
-          <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950/30 p-4">
-            <p className="text-xs font-semibold text-purple-600 dark:text-purple-400 mb-3">🎉 WEEKENDS (Sat–Sun)</p>
+          <div className="rounded-lg border border-coral-400/30 bg-coral-500/5 dark:bg-coral-500/10 p-4">
+            <p className="text-xs font-semibold text-coral-500 dark:text-coral-400 mb-3">🎉 WEEKENDS (Sat–Sun)</p>
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
                 <span className="text-slate-500 dark:text-slate-400">Total Spend</span>
@@ -383,13 +383,13 @@ export default function SpendingRhythm() {
                 <span className="text-slate-500 dark:text-slate-400">Avg / Day</span>
                 <span className="font-semibold">{formatIdr(wv.weekendAvgPerDay)}</span>
               </div>
-              <div className="pt-2 border-t border-purple-200 dark:border-purple-800">
+              <div className="pt-2 border-t border-coral-400/30">
                 <div className="flex justify-between text-xs mb-1">
                   <span className="text-slate-400">Share of spend</span>
-                  <span className="font-medium text-purple-600 dark:text-purple-400">{wv.weekendPctSpend}%</span>
+                  <span className="font-medium text-coral-500 dark:text-coral-400">{wv.weekendPctSpend}%</span>
                 </div>
-                <div className="h-2 rounded-full bg-purple-100 dark:bg-purple-900/40 overflow-hidden">
-                  <div className="h-full bg-purple-500 rounded-full" style={{ width: `${wv.weekendPctSpend}%` }}></div>
+                <div className="h-2 rounded-full bg-coral-100 dark:bg-coral-900/40 overflow-hidden">
+                  <div className="h-full bg-coral-500 rounded-full" style={{ width: `${wv.weekendPctSpend}%` }}></div>
                 </div>
               </div>
             </div>
@@ -408,10 +408,10 @@ export default function SpendingRhythm() {
             <div
               key={bucket.label}
               className={`rounded-lg border p-4 ${
-                bucket.label === 'Late Night' ? 'border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/30'
-                : bucket.label === 'Morning' ? 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30'
+                bucket.label === 'Late Night' ? 'border-navy-300 dark:border-navy-700 bg-navy-500/5 dark:bg-navy-500/10'
+                : bucket.label === 'Morning' ? 'border-gold-400/30 bg-gold-500/5 dark:bg-gold-500/10'
                 : bucket.label === 'Afternoon' ? 'border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/30'
-                : 'border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-950/30'
+                : 'border-gold-400/30 bg-gold-500/5 dark:bg-gold-500/10'
               }`}
             >
               <div className="flex items-center justify-between mb-2">
@@ -424,10 +424,10 @@ export default function SpendingRhythm() {
               <div className="mt-2 h-1.5 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
                 <div
                   className={`h-full rounded-full ${
-                    bucket.label === 'Late Night' ? 'bg-indigo-400'
-                    : bucket.label === 'Morning' ? 'bg-amber-400'
+                    bucket.label === 'Late Night' ? 'bg-navy-400'
+                    : bucket.label === 'Morning' ? 'bg-gold-400'
                     : bucket.label === 'Afternoon' ? 'bg-orange-400'
-                    : 'bg-violet-400'
+                    : 'bg-gold-400'
                   }`}
                   style={{ width: `${bucket.pctOfTx}%` }}
                 ></div>
@@ -442,7 +442,7 @@ export default function SpendingRhythm() {
       {data.categoryHeatmap.length > 0 && (
         <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
           <h3 className="flex items-center gap-2 text-sm font-semibold mb-4">
-            <TrendingUp className="w-4 h-4 text-indigo-500" />
+            <TrendingUp className="w-4 h-4 text-mint-500" />
             Category × Weekday Heatmap
           </h3>
           <p className="text-xs text-slate-400 mb-3">Spending intensity by category across weekdays. Darker = more spending.</p>
@@ -454,7 +454,7 @@ export default function SpendingRhythm() {
                   {data.dowStats.map((s) => (
                     <th
                       key={s.dow}
-                      className={`px-1 py-2 text-center font-medium ${s.isWeekend ? 'text-purple-500' : 'text-slate-400'}`}
+                      className={`px-1 py-2 text-center font-medium ${s.isWeekend ? 'text-coral-500' : 'text-slate-400'}`}
                     >
                       {s.shortLabel}
                     </th>

--- a/src/components/SpendingStreaks.tsx
+++ b/src/components/SpendingStreaks.tsx
@@ -83,10 +83,10 @@ function formatDateLabel(dateStr: string): string {
 function spendIntensity(total: number): string {
   if (total <= 0) return '';
   // Buckets: <200k, <500k, <1M, <2M, >=2M
-  if (total < 200000) return 'bg-amber-200 dark:bg-amber-900/50';
-  if (total < 500000) return 'bg-amber-300 dark:bg-amber-800/60';
-  if (total < 1000000) return 'bg-orange-300 dark:bg-orange-800/70';
-  if (total < 2000000) return 'bg-orange-400 dark:bg-orange-700/80';
+  if (total < 200000) return 'bg-gold-400/20 dark:bg-gold-700/30';
+  if (total < 500000) return 'bg-gold-400/30 dark:bg-gold-700/30';
+  if (total < 1000000) return 'bg-coral-400/30 dark:bg-coral-700/40';
+  if (total < 2000000) return 'bg-coral-400 dark:bg-coral-700/80';
   return 'bg-red-500 dark:bg-red-600/90';
 }
 
@@ -174,16 +174,16 @@ export default function SpendingStreaks() {
         {/* Current streak */}
         <div className={`rounded-xl border p-6 shadow-sm transition ${
           data.currentStreak > 0
-            ? 'bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-950/40 dark:to-amber-950/30 border-orange-200 dark:border-orange-800'
+            ? 'bg-gradient-to-br from-coral-500/5 to-gold-500/5 dark:from-coral-700/10/40 dark:to-gold-700/5/30 border-coral-400/20 dark:border-coral-700/40'
             : 'bg-white/[0.03] border-white/[0.06]'
         }`}>
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/50">
               Current Streak
             </p>
-            <Flame className={`w-5 h-5 ${data.currentStreak > 0 ? 'text-orange-500' : 'text-white/30'}`} />
+            <Flame className={`w-5 h-5 ${data.currentStreak > 0 ? 'text-coral-500/50' : 'text-white/30'}`} />
           </div>
-          <p className={`text-4xl font-bold mt-3 ${data.currentStreak > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-white/40'}`}>
+          <p className={`text-4xl font-bold mt-3 ${data.currentStreak > 0 ? 'text-coral-500 dark:text-coral-400' : 'text-white/40'}`}>
             {data.currentStreak}
             <span className="text-lg font-medium ml-1">day{data.currentStreak === 1 ? '' : 's'}</span>
           </p>
@@ -256,7 +256,7 @@ export default function SpendingStreaks() {
         <div className="lg:col-span-2 glass-card p-6">
           <div className="flex items-center justify-between mb-1">
             <h2 className="text-lg font-semibold flex items-center gap-2">
-              <Sparkles className="w-4 h-4 text-amber-500" /> Last 5 Weeks
+              <Sparkles className="w-4 h-4 text-gold-500" /> Last 5 Weeks
             </h2>
           </div>
           <p className="text-xs text-white/50 mb-4">
@@ -293,10 +293,10 @@ export default function SpendingStreaks() {
               <span className="w-3 h-3 rounded-sm bg-emerald-400 dark:bg-emerald-600 inline-block" /> No spend
             </span>
             <span>Less</span>
-            <span className="w-3 h-3 rounded-sm bg-amber-200 dark:bg-amber-900/50 inline-block" />
-            <span className="w-3 h-3 rounded-sm bg-amber-300 dark:bg-amber-800/60 inline-block" />
-            <span className="w-3 h-3 rounded-sm bg-orange-300 dark:bg-orange-800/70 inline-block" />
-            <span className="w-3 h-3 rounded-sm bg-orange-400 dark:bg-orange-700/80 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-gold-400/20 dark:bg-gold-700/30 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-gold-400/30 dark:bg-gold-700/30 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-coral-400/30 dark:bg-coral-700/40 inline-block" />
+            <span className="w-3 h-3 rounded-sm bg-coral-400 dark:bg-coral-700/80 inline-block" />
             <span className="w-3 h-3 rounded-sm bg-red-500 dark:bg-red-600/90 inline-block" />
             <span>More</span>
           </div>
@@ -323,7 +323,7 @@ export default function SpendingStreaks() {
                   <div className="flex items-center gap-2">
                     <div className="flex-1 h-2.5 bg-white/[0.05] rounded-full overflow-hidden">
                       <div
-                        className={`h-full rounded-full ${intensityPct > 75 ? 'bg-red-400 dark:bg-red-500' : intensityPct > 50 ? 'bg-orange-400 dark:bg-orange-500' : 'bg-amber-400 dark:bg-amber-500'}`}
+                        className={`h-full rounded-full ${intensityPct > 75 ? 'bg-red-400 dark:bg-coral-600' : intensityPct > 50 ? 'bg-coral-400 dark:bg-coral-500' : 'bg-gold-400 dark:bg-gold-500/50'}`}
                         style={{ width: `${spendPct}%` }}
                       />
                     </div>
@@ -353,7 +353,7 @@ export default function SpendingStreaks() {
       <div className="glass-card p-6">
         <div className="flex items-center justify-between mb-1">
           <h2 className="text-lg font-semibold flex items-center gap-2">
-            <Trophy className="w-4 h-4 text-amber-500" /> Badges
+            <Trophy className="w-4 h-4 text-gold-500" /> Badges
           </h2>
           <Badge variant="secondary">
             {data.badges.filter((b) => b.unlocked).length} / {data.badges.length} unlocked
@@ -368,13 +368,13 @@ export default function SpendingStreaks() {
               key={b.id}
               className={`rounded-xl border p-4 transition ${
                 b.unlocked
-                  ? 'bg-gradient-to-br from-amber-50 to-yellow-50 dark:from-amber-950/30 dark:to-yellow-950/20 border-amber-200 dark:border-amber-800'
+                  ? 'bg-gradient-to-br from-gold-500/5 to-gold-500/5 dark:from-gold-700/10/30 dark:to-gold-700/5/20 border-gold-400/20 dark:border-gold-700/40'
                   : 'bg-white/[0.03] border-white/[0.06] opacity-70'
               }`}
             >
               <div className="flex items-start justify-between mb-2">
                 <span className={`text-3xl ${b.unlocked ? '' : 'grayscale opacity-50'}`}>{b.icon}</span>
-                {b.unlocked && <span className="text-[10px] font-bold uppercase text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 rounded">Earned</span>}
+                {b.unlocked && <span className="text-[10px] font-bold uppercase text-gold-600 dark:text-gold-400 bg-gold-500/10 dark:bg-gold-700/20 px-1.5 py-0.5 rounded">Earned</span>}
               </div>
               <p className={`font-semibold text-sm ${b.unlocked ? 'text-white/80' : 'text-white/50'}`}>
                 {b.label}
@@ -383,7 +383,7 @@ export default function SpendingStreaks() {
               {!b.unlocked && b.progress && (
                 <div className="mt-2">
                   <div className="w-full bg-white/[0.08] rounded-full h-1.5">
-                    <div className="h-1.5 rounded-full bg-amber-400 dark:bg-amber-500 transition-all" style={{ width: `${Math.min(100, (b.progress.current / b.progress.target) * 100)}%` }} />
+                    <div className="h-1.5 rounded-full bg-gold-400 dark:bg-gold-500/50 transition-all" style={{ width: `${Math.min(100, (b.progress.current / b.progress.target) * 100)}%` }} />
                   </div>
                   <p className="text-[10px] text-white/40 mt-1">{b.progress.current} / {b.progress.target}</p>
                 </div>

--- a/src/components/SpendingStreaks.tsx
+++ b/src/components/SpendingStreaks.tsx
@@ -199,14 +199,14 @@ export default function SpendingStreaks() {
         </div>
 
         {/* Longest streak */}
-        <div className="rounded-xl border p-6 shadow-sm bg-gradient-to-br from-violet-50 to-purple-50 dark:from-violet-950/40 dark:to-purple-950/30 border-violet-200 dark:border-violet-800">
+        <div className="rounded-xl border p-6 shadow-sm bg-gradient-to-br dark:from-navy-800/40 dark:to-navy-900/30 border-white/[0.08]">
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-white/50">
               Longest Streak
             </p>
-            <Trophy className="w-5 h-5 text-violet-500" />
+            <Trophy className="w-5 h-5 text-gold-500" />
           </div>
-          <p className="text-4xl font-bold mt-3 text-violet-600 dark:text-violet-400">
+          <p className="text-4xl font-bold mt-3 text-gold-400 dark:text-gold-400">
             {data.longestStreak}
             <span className="text-lg font-medium ml-1">day{data.longestStreak === 1 ? '' : 's'}</span>
           </p>

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -588,16 +588,16 @@ export default function TransactionTable({ transactions, showMonth = true, perio
 
                 const typeColorClass =
                   row.type === 'cash'
-                    ? 'text-blue-400'
+                    ? 'text-mint-400'
                     : row.type === 'credit_payment'
-                    ? 'text-amber-400'
-                    : 'text-purple-400';
+                    ? 'text-gold-400'
+                    : 'text-coral-400';
                 const typeBgClass =
                   row.type === 'cash'
-                    ? 'bg-blue-500/10'
+                    ? 'bg-mint-500/30/10'
                     : row.type === 'credit_payment'
-                    ? 'bg-amber-500/10'
-                    : 'bg-purple-500/10';
+                    ? 'bg-gold-500/10'
+                    : 'bg-coral-500/10';
                 const typeLabel =
                   row.type === 'cash' ? 'Cash' : row.type === 'credit_payment' ? 'Credit Pay' : 'Credit';
 
@@ -629,7 +629,7 @@ export default function TransactionTable({ transactions, showMonth = true, perio
                     <TableCell className="py-2.5">
                       <span className="text-white/80">{row.title}</span>
                       {row.notes && (
-                        <StickyNote className="inline ml-1.5 align-middle w-3 h-3 text-amber-400 shrink-0" title={row.notes} />
+                        <StickyNote className="inline ml-1.5 align-middle w-3 h-3 text-gold-400 shrink-0" title={row.notes} />
                       )}
                     </TableCell>
                     <TableCell className="py-2.5">

--- a/src/components/WeeklyTracker.tsx
+++ b/src/components/WeeklyTracker.tsx
@@ -80,7 +80,7 @@ function generateInsights(data: WeeklySpendingResult): { icon: React.ReactNode; 
   if (overBudgetWeeks.length > 0) {
     const pctOver = Math.round(((overBudgetWeeks[0].total - weeklyBudget) / weeklyBudget) * 100);
     insights.push({
-      icon: <AlertTriangle className="w-4 h-4 text-amber-500" />,
+      icon: <AlertTriangle className="w-4 h-4 text-gold-500" />,
       text: `${overBudgetWeeks.length} of ${weeks.length} weeks exceeded your weekly budget (${formatIdr(weeklyBudget)}). The worst was ${overBudgetWeeks[0].label} at ${pctOver}% over.`,
       type: 'warn',
     });
@@ -90,7 +90,7 @@ function generateInsights(data: WeeklySpendingResult): { icon: React.ReactNode; 
   if (weeks.length >= 3 && weeks[0].total > weeks[1].total * 2) {
     const pct = Math.round((weeks[0].total / totalSpend) * 100);
     insights.push({
-      icon: <Zap className="w-4 h-4 text-orange-500" />,
+      icon: <Zap className="w-4 h-4 text-coral-500/50" />,
       text: `${pct}% of all spending happened in Week 1 — a "kickoff spike" pattern. Consider spreading early-month payments.`,
       type: 'info',
     });
@@ -145,7 +145,7 @@ function generateInsights(data: WeeklySpendingResult): { icon: React.ReactNode; 
     if (topCat) {
       const catPct = Math.round((topCat[1] / totalSpend) * 100);
       insights.push({
-        icon: <Wallet className="w-4 h-4 text-blue-500" />,
+        icon: <Wallet className="w-4 h-4 text-mint-500" />,
         text: `Your biggest spending category is "${topCat[0]}" at ${formatIdr(topCat[1])} (${catPct}% of total).`,
         type: 'info',
       });
@@ -439,10 +439,10 @@ export default function WeeklyTracker() {
 
       {/* Insights */}
       {insights.length > 0 && (
-        <div className="glass-card p-5 border-indigo-200 dark:border-indigo-800/50 bg-indigo-50/50 dark:bg-indigo-950/20">
+        <div className="glass-card p-5 border-mint-400/30 dark:border-mint-500/20/50 bg-mint-500/5/50 dark:bg-mint-500/10/20">
           
             <h3 className="text-sm font-medium flex items-center gap-2 text-white/80">
-              <Target className="w-4 h-4 text-indigo-500" />
+              <Target className="w-4 h-4 text-mint-500" />
               Weekly Insights
             </h3>
           
@@ -451,7 +451,7 @@ export default function WeeklyTracker() {
               {insights.map((ins, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm">
                   {ins.icon}
-                  <span className={ins.type === 'bad' ? 'text-red-700 dark:text-red-400' : ins.type === 'warn' ? 'text-amber-700 dark:text-amber-400' : 'text-white/60'}>
+                  <span className={ins.type === 'bad' ? 'text-red-700 dark:text-red-400' : ins.type === 'warn' ? 'text-gold-700 dark:text-gold-400' : 'text-white/60'}>
                     {ins.text}
                   </span>
                 </li>
@@ -497,7 +497,7 @@ export default function WeeklyTracker() {
                     onClick={() => setSelectedWeek(selectedWeek === w.weekNum ? null : w.weekNum)}
                     className={`w-full text-left p-3 rounded-lg border transition cursor-pointer ${
                       selectedWeek === w.weekNum
-                        ? 'border-indigo-400 dark:border-indigo-500 bg-indigo-50 dark:bg-indigo-950/30'
+                        ? 'border-mint-400 dark:border-mint-500 bg-mint-500/5 dark:bg-mint-500/10'
                         : 'border-white/[0.06] hover:border-white/[0.15]'
                     }`}
                   >
@@ -547,7 +547,7 @@ export default function WeeklyTracker() {
                                   <div className="flex items-center gap-2">
                                     <div className="w-16 h-1.5 bg-white/[0.05] rounded-full">
                                       <div
-                                        className="h-full rounded-full bg-indigo-400"
+                                        className="h-full rounded-full bg-mint-400"
                                         style={{ width: `${catPct}%` }}
                                       />
                                     </div>

--- a/src/components/WhatIfPlanner.tsx
+++ b/src/components/WhatIfPlanner.tsx
@@ -365,7 +365,7 @@ export default function WhatIfPlanner() {
           </div>
         <div className="glass-card p-5">
           <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">Savings Rate</p>
-            <p className={`text-xl font-bold mt-1 ${projection.adjustedIncome > 0 && projection.monthlyNet / projection.adjustedIncome >= 0.2 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}>
+            <p className={`text-xl font-bold mt-1 ${projection.adjustedIncome > 0 && projection.monthlyNet / projection.adjustedIncome >= 0.2 ? 'text-emerald-600 dark:text-emerald-400' : 'text-gold-600 dark:text-gold-400'}`}>
               {projection.adjustedIncome > 0 ? ((projection.monthlyNet / projection.adjustedIncome) * 100).toFixed(1) : '0'}%
             </p>
             <p className="text-[11px] mt-1 text-muted-foreground">

--- a/src/components/WhatIfPlanner.tsx
+++ b/src/components/WhatIfPlanner.tsx
@@ -587,7 +587,7 @@ export default function WhatIfPlanner() {
 
       {/* ─── Reset & Insight Bar ───────────────────────────────────────────── */}
       {(incomeChangePct !== 0 || Object.keys(categoryAdjustments).length > 0 || oneTimeEvents.length > 0) && (
-        <div className={`glass-card p-5 border-l-4 ${projection.networthDifference >= 0 ? 'border-l-emerald-500' : 'border-l-amber-500'}`}>
+        <div className="glass-card p-5">
           <div className="flex-1 min-w-0">
               <p className="text-sm font-medium">
                 {projection.networthDifference >= 0 ? '✅' : '⚠️'}{' '}

--- a/src/components/YearlyReport.tsx
+++ b/src/components/YearlyReport.tsx
@@ -295,8 +295,8 @@ export default function YearlyReport({ summaries, categories }: Props) {
               </div>
             <div className="glass-card p-5">
               <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
-                    <TrendingUp className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                  <div className="p-2 rounded-lg bg-mint-500/10 dark:bg-mint-700/20">
+                    <TrendingUp className="w-5 h-5 text-mint-500 dark:text-mint-400" />
                   </div>
                   <div>
                     <p className="text-xs text-muted-foreground">Avg Savings Rate</p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,8 +68,8 @@ const { title = 'Financial Dashboard', balance, alerts = 0 } = Astro.props;
     <!-- Desktop Top Bar -->
     <div class="hidden lg:flex items-center justify-between h-16 px-6 border-b border-white/[0.05] ml-[240px] transition-all duration-300" id="desktop-topbar">
       <div>
-        <h1 class="text-lg font-bold text-white">{title}</h1>
-        <p class="text-xs text-white/30">Financial Dashboard</p>
+        <h1 class="text-xl font-bold text-white">{title}</h1>
+        <p class="text-xs text-white/40">Financial Dashboard</p>
       </div>
       <div class="flex items-center gap-3">
         <!-- Dark mode toggle (desktop) -->
@@ -94,7 +94,7 @@ const { title = 'Financial Dashboard', balance, alerts = 0 } = Astro.props;
     <!-- Mobile Bottom Tabs -->
     <FintechBottomTabs client:load />
 
-    <footer class="text-center text-xs text-white/20 pb-8 hidden lg:block">
+    <footer class="text-center text-xs text-white/30 pb-8 hidden lg:block">
       Financial Dashboard · Built with Astro & React
     </footer>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,4 +60,23 @@
   .glass-nav {
     @apply bg-navy-950/80 backdrop-blur-xl border-b border-white/[0.06];
   }
+
+  /* Sidebar scrollbar */
+  .sidebar-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,0.08) transparent;
+  }
+  .sidebar-scroll::-webkit-scrollbar {
+    width: 4px;
+  }
+  .sidebar-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .sidebar-scroll::-webkit-scrollbar-thumb {
+    background-color: rgba(255,255,255,0.08);
+    border-radius: 4px;
+  }
+  .sidebar-scroll::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255,255,255,0.15);
+  }
 }


### PR DESCRIPTION
## Summary

Impeccable design critique (`$impeccable critique`) scored the dashboard **22/40 (Acceptable)**. This PR addresses the 3 top-priority issues found.

## Critique Score: 22/40 → expected 28-32/40 after fixes

### Issues Fixed

| Issue | Title | Commits | Files |
|-------|-------|---------|-------|
| #125 | Replace off-palette colors with navy/mint/coral/gold | 3 | 43 |
| #126 | Remove side-tab accent borders from glass cards | 1 | 4 |
| #127 | Fix flat typography hierarchy & invisible section labels | 2 | 2 |

### #125 — Off-Palette Color Cleanup
- **Before:** 14 detector findings for `ai-color-palette` (purple/violet/indigo/fuchsia/cyan)
- **After:** 0 findings. All replaced with palette: `navy`, `mint`, `coral`, `gold`
- Replaced: purple→coral, violet→gold, indigo→mint, amber→gold, blue→mint, cyan→mint, orange→coral, pink→coral
- Standardized ALL loading spinners to `border-mint-500/40`

### #126 — Side-Tab Accent Borders
- **Before:** 6 detector findings for `side-tab` (border-l-4 on rounded cards)
- **After:** 0 findings. Removed all `border-l-4`/`border-l-2` from glass cards in RecurringCostAnalyzer, WhatIfPlanner, BudgetAlerts, BudgetReport

### #127 — Typography Hierarchy
- Desktop page title: `text-lg` → `text-xl` (18→20px)
- Section eyebrows: `text-white/20` → `text-white/40` (WCAG AA contrast)
- Footer: `text-white/20` → `text-white/30`
- Type ratio improved from 1.5:1 → 1.7:1

## Detector Results
- **Before:** 29 findings (14 ai-color-palette, 8 border-accent-on-rounded, 6 side-tab, 1 flat-type-hierarchy)
- **After:** 9 findings (8 border-accent-on-rounded = loading spinner false positives, 1 flat-type-hierarchy = improved but needs more steps)

## Build
✅ `npm run build` passes. PM2 restarted.

## Test Plan
- [ ] Visual diff on dashboard — credit expenses should now be coral, not purple
- [ ] Check /streaks, /analytics, /achievements — no more violet/indigo gradients
- [ ] Check /recurring-audit — no border-l accent on cards
- [ ] Mobile: section labels (PULSE/FLOW/etc) should be more visible
- [ ] All loading spinners should be mint-colored

Closes #125, #126, #127