### PR TITLE
fix: remove duplicate page title from header

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,7 +46,7 @@ const { title = 'Financial Dashboard', balance, alerts = 0 } = Astro.props;
       <a href="/" class="w-8 h-8 rounded-lg flex items-center justify-center no-underline" style="background:linear-gradient(135deg, #34d399, #0ea5e9)">
         <span class="text-slate-900 dark:text-white font-bold text-xs">FD</span>
       </a>
-      <h1 class="text-sm font-bold text-foreground dark:text-white">{title}</h1>
+      <div></div>
       <div class="flex items-center gap-1.5">
         <!-- Settings (mobile) -->
         <a href="/settings" class="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted dark:text-white/60 dark:hover:text-white dark:hover:bg-white/10 transition" aria-label="Settings">
@@ -67,10 +67,6 @@ const { title = 'Financial Dashboard', balance, alerts = 0 } = Astro.props;
 
     <!-- Desktop Top Bar -->
     <div class="hidden lg:flex items-center justify-between h-16 px-6 border-b border-border dark:border-white/[0.05] ml-[240px] transition-all duration-300" id="desktop-topbar">
-      <div>
-        <h1 class="text-xl font-bold text-foreground dark:text-white">{title}</h1>
-        <p class="text-xs text-muted-foreground dark:text-white/40">Financial Dashboard</p>
-      </div>
       <div class="flex items-center gap-3">
         <!-- Dark mode toggle (desktop) -->
         <button onclick="(function(){var h=document.documentElement;var d=h.classList.toggle('dark');localStorage.setItem('theme',d?'dark':'light')})()" class="p-2 rounded-xl bg-muted dark:bg-white/[0.05] text-muted-foreground dark:text-white/60 dark:hover:text-white hover:bg-accent dark:hover:bg-white/10 transition" aria-label="Toggle theme">


### PR DESCRIPTION
Page titles already exist within each page's content. Removed duplicate from:
- Mobile top bar
- Desktop top bar (title + subtitle)